### PR TITLE
Add brew cask install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,12 @@ A light, Electron-based wrapper around GraphiQL.
 
 Provides a tabbed interface for editing and testing GraphQL queries/mutations with GraphiQL.
 
-Download the binary from the [Releases](https://github.com/skevy/graphiql-app/releases) tab.
+#### Installation
+
+If you have [Homebrew](http://brew.sh/) installed on OSX:
+
+```
+brew cask install graphiql
+```
+
+Alternately, download the binary from the [Releases](https://github.com/skevy/graphiql-app/releases) tab.


### PR DESCRIPTION
I added the `brew cask install` instructions now that GraphiQL-app is available via homebrew cask.