### PR TITLE
Make endpoint field responsive

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -107,22 +107,41 @@ body {
 }
 
 .config-form {
-  padding: 20px;
+  padding: 12px;
+  display: flex;
+  justify-content: space-around;
+  flex-wrap: wrap;
 }
 
 .field {
   display: flex;
-  height: 40px;
   flex-direction: row;
   align-items: center;
-  justify-content: center;
-  float: left;
-  margin-right: 30px;
+  margin: 0 12px;
+}
+
+.endpoint-box {
+  flex: 1;
+}
+
+.endpoint-box input {
+  width: 100%;
+}
+
+.endpoint-box label {
+  text-align: center;
+}
+
+@media (max-width: 700px) {
+  .endpoint-box {
+    width: 100%;
+    flex: initial;
+    margin-bottom: 15px;
+  }
 }
 
 .field label {
   margin-right: 20px;
-  line-height: 35px;
 }
 
 .field input, .field select {
@@ -131,3 +150,4 @@ body {
   font-weight: bold;
   font-size: 20px;
 }
+

--- a/app/components/App.js
+++ b/app/components/App.js
@@ -237,7 +237,7 @@ export default class App extends React.Component {
     const tabEl = (
       <div key={currentTabKey} className="tabs__tab">
         <div className="config-form clearfix">
-          <div className="field">
+          <div className="field endpoint-box">
             <label htmlFor="endpoint">GraphQL Endpoint</label>
             <input type="text" name="endpoint"
               value={currentTab.endpoint} onChange={this.handleChange.bind(this, 'endpoint')} />


### PR DESCRIPTION
The endpoint text field is sometimes too narrow, and I keep having to scroll through the field to change the url.
This can be a little annoying some times.
I made some changes that should make it look a little better.

I also took the chance to clean up some styles a little bit.

Thank you!

Before:
![graphiql-original](https://cloud.githubusercontent.com/assets/270688/12935842/d83c402e-cf4d-11e5-8712-ff4cce6044a4.gif)

After:
![graphiql-responsive](https://cloud.githubusercontent.com/assets/270688/12935836/c56ad802-cf4d-11e5-9100-7f24220d06f2.gif)

