### PR TITLE
remove scroll bars from tab interface

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -41,8 +41,6 @@ body {
 .tab-bar {
   width: 100%;
   height: 46px;
-  overflow-y: visible;
-  overflow-x: scroll;
 }
 
 .tab-bar-inner {


### PR DESCRIPTION
This commit removes the scroll bars that show up around the tab component.

This is only happening when I run graphiql-app on linux (which I'm running on a virtual box vm, so I can't take screenshots for some reason)