### PR TITLE
Add autorelease functionality to GitHub Releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start-dev": "NODE_ENV=development electron .",
     "start-hot": "HOT=1 NODE_ENV=development electron .",
     "package": "node package.js --name=GraphiQL",
-    "package-all": "node package.js --name=GraphiQL --all"
+    "package-all": "node package.js --name=GraphiQL --all",
+    "release": "npm run package-all && node node_modules/electron-release/cli.js"
   },
   "author": "Adam Miskiewicz <adam.skevy@mac.com> (http://github.com/skevy)",
   "license": "MIT",
@@ -41,6 +42,7 @@
     "electron-packager": "^5.1.0",
     "electron-prebuilt": "^0.33.4",
     "electron-rebuild": "^1.0.0",
+    "electron-release": "^2.2.0",
     "extract-text-webpack-plugin": "^0.8.2",
     "file-loader": "^0.8.4",
     "github-latest-release": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start-hot": "HOT=1 NODE_ENV=development electron .",
     "package": "node package.js --name=GraphiQL --prune",
     "package-all": "node package.js --name=GraphiQL --all --prune",
-    "release": "npm run package-all && node electron-release"
+    "release": "node node_modules/electron-release/cli --app release/darwin-x64/GraphiQL-darwin-x64/GraphiQL.app --token node -e \"console.log(process.env.GITHUB_TOKEN)\""
   },
   "author": "Adam Miskiewicz <adam.skevy@mac.com> (http://github.com/skevy)",
   "license": "MIT",


### PR DESCRIPTION
This adds https://github.com/jenslind/electron-release to the dependencies, as well as a new _package.json_ script to release the zipped binary to GitHub Release.

Down the line, this will also set this app up for autoupdates via Electron/Squirrel. 