### PR TITLE
Allow more tabs be removing fixed width

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -64,8 +64,6 @@ body {
 .tab-bar li {
   display: flex;
   list-style-type: none;
-  width: 150px;
-  flex-basis: 150px;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
I'm testing a newly converted API of mine and I wanted to keep examples right in GraphiQL when I stumble upon a UI limitation. To fix it, I've simply remove the fixed width of the tabs.

**Before**
![capture d ecran 2016-10-05 a 21 15 05](https://cloud.githubusercontent.com/assets/27001/19137364/34029368-8b41-11e6-9c4c-b71cd5735c30.png)

**After**
![capture d ecran 2016-10-05 a 21 13 59](https://cloud.githubusercontent.com/assets/27001/19137367/3f15c81a-8b41-11e6-945b-bc0236bfff38.png)

✌️ 
