### PR TITLE
[RFC] Fix ReactComponentBrowserEnvironment path

### DIFF
--- a/webpack/make-webpack-config.js
+++ b/webpack/make-webpack-config.js
@@ -80,7 +80,7 @@ module.exports = function(opts) {
 
   var plugins = [
     new webpack.PrefetchPlugin('react'),
-    new webpack.PrefetchPlugin('react/lib/ReactComponentBrowserEnvironment')
+    new webpack.PrefetchPlugin('react-dom/lib/ReactComponentBrowserEnvironment')
   ];
 
   if (opts.prerender) {


### PR DESCRIPTION
Seems like react moved ReactComponentBrowserEnvironment from `react` node module to `react-dom`.

Closes #49 