### PR TITLE
Fix bad JSON stringify in get requests

### DIFF
--- a/app/components/App.js
+++ b/app/components/App.js
@@ -164,7 +164,7 @@ export default class App extends React.Component {
 
       url += url.indexOf('?') == -1 ? "?" : "&";
 
-      return fetch(url + "query=" + encodeURIComponent(graphQLParams['query']) + "&variables=" + encodeURIComponent(graphQLParams['variables']), {
+      return fetch(url + "query=" + encodeURIComponent(graphQLParams['query']) + "&variables=" + encodeURIComponent(JSON.stringify(graphQLParams['variables'])), {
         method: method,
         credentials: 'include',
         headers: Object.assign({}, defaultHeaders, headers),


### PR DESCRIPTION
# Bad `GET` requests were sent
Not sure if this fixes #52 but it's worth checking. It definitely fixes my [issue](https://github.com/graphql/graphiql/issues/416#issuecomment-301242009). I'm not sure why the query parameter didn't cause any issues as the object given there wasn't (and still isn't) `JSON.stringified`.