### PR TITLE
Add Origin header for CORS support

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,6 +23,11 @@ app.on('ready', function() {
 
   mainWindow = new BrowserWindow({ width: 1024, height: 728 });
 
+  electron.session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+    details.requestHeaders['Origin'] = 'electron://graphiql-app';
+    callback({ cancel: false, requestHeaders: details.requestHeaders });
+  });
+
   if (process.env.HOT) {
     mainWindow.loadURL('file://' + __dirname + '/app/hot-dev-app.html');
   } else {


### PR DESCRIPTION
It seems adding the header inside App.js doesn't work for Origin or User-Agent but you can hack it like this.

I went with: `electron://graphiql-app` as there's a similar notation for chrome-webapps like: `chrome-extension://abc123`

Closes #53