### PR TITLE
add the close query menu item for non-macOS

### DIFF
--- a/main.js
+++ b/main.js
@@ -79,13 +79,13 @@ app.on('ready', function() {
       label: 'File',
       submenu: [{
         label: 'New Query',
-        accelerator: 'CmdOrCtrl+T',
+        accelerator: 'Command+T',
         click: function() {
           mainWindow.webContents.send('handleElectronMenuOption', 'NEW_TAB');
         }
       }, {
         label: 'Close Query',
-        accelerator: 'CmdOrCtrl+W',
+        accelerator: 'Command+W',
         click: function() {
           mainWindow.webContents.send('handleElectronMenuOption', 'CLOSE_TAB');
         }
@@ -193,6 +193,12 @@ app.on('ready', function() {
         accelerator: 'Ctrl+N',
         click: function() {
           mainWindow.webContents.send('handleElectronMenuOption', 'NEW_TAB');
+        }
+      }, {
+        label: 'Close Query',
+        accelerator: 'Ctrl+W',
+        click: function() {
+          mainWindow.webContents.send('handleElectronMenuOption', 'CLOSE_TAB');
         }
       }]
     }, {

--- a/main.js
+++ b/main.js
@@ -79,13 +79,13 @@ app.on('ready', function() {
       label: 'File',
       submenu: [{
         label: 'New Query',
-        accelerator: 'Command+T',
+        accelerator: 'CmdOrCtrl+T',
         click: function() {
           mainWindow.webContents.send('handleElectronMenuOption', 'NEW_TAB');
         }
       }, {
         label: 'Close Query',
-        accelerator: 'Command+W',
+        accelerator: 'CmdOrCtrl+W',
         click: function() {
           mainWindow.webContents.send('handleElectronMenuOption', 'CLOSE_TAB');
         }


### PR DESCRIPTION
Fixes #70 

 - [x] add in the missing menu item and keybinding