### PR TITLE
Fix errors on boot

### DIFF
--- a/app/components/App.js
+++ b/app/components/App.js
@@ -154,6 +154,15 @@ export default class App extends React.Component {
       'Content-Type': 'application/json'
     };
 
+    const error = {
+                    "data" : null,
+                    "errors": [
+                      {
+                        "message": "I couldn't communicate with the GraphQL server at the provided URL. Is it correct?"
+                      }
+                    ]
+                  };
+
     const { endpoint, method, headers } = this.getCurrentTab();
 
     if (endpoint == "") {
@@ -166,6 +175,8 @@ export default class App extends React.Component {
         ]
       });
     }
+
+
 
     if (method == "get") {
       var url = endpoint;
@@ -180,14 +191,16 @@ export default class App extends React.Component {
         credentials: 'include',
         headers: Object.assign({}, defaultHeaders, headers),
         body: null
-      }).then(response => response.json());
+      }).then(response => response.json())
+        .catch(reason => error);
     }
     return fetch(endpoint, {
       method: method,
       credentials: 'include',
       headers: Object.assign({}, defaultHeaders, headers),
       body: JSON.stringify(graphQLParams)
-    }).then(response => response.json());
+    }).then(response => response.json())
+      .catch(reason => error);
   }
 
   handleChange(field, eOrKey, e) {

--- a/app/components/App.js
+++ b/app/components/App.js
@@ -156,6 +156,17 @@ export default class App extends React.Component {
 
     const { endpoint, method, headers } = this.getCurrentTab();
 
+    if (endpoint == "") {
+      return Promise.resolve({
+        "data" : null,
+        "errors": [
+          {
+            "message": "Provide a URL to a GraphQL endpoint to start making queries to it!"
+          }
+        ]
+      });
+    }
+
     if (method == "get") {
       var url = endpoint;
       if (typeof graphQLParams['variables'] === "undefined"){

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev-server": "webpack-dev-server --config webpack/webpack-dev-server.config.js --progress --colors --port 2992 --inline",
     "hot-dev-server": "webpack-dev-server --config webpack/webpack-hot-dev-server.config.js --hot --progress --colors --port 2992 --inline",
+    "build-dev": "webpack --config webpack/webpack.config.js --progress --profile --colors",
     "build": "webpack --config webpack/webpack.config.production.js --progress --profile --colors",
     "start": "electron .",
     "start-dev": "NODE_ENV=development electron .",

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -1,3 +1,3 @@
-module.exports = require('./make-webpack-config')({})
-
-
+module.exports = require('./make-webpack-config')({
+  devtool: 'eval-source-map'
+})


### PR DESCRIPTION
Should close https://github.com/skevy/graphiql-app/issues/82 and https://github.com/skevy/graphiql-app/issues/90.

When the app first launches, it immediately tries to grab a schema from an endpoint URL. But if there's no URL, the `fetch` function fails with an obscure error.