### PR TITLE
Add snap support

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "chai-as-promised": "^5.3.0",
     "css-loader": "^0.19.0",
     "del": "^2.0.2",
-    "electron-builder": "^19.4.2",
+    "electron-builder": "^19.53.0",
     "electron-packager": "^8.7.1",
     "electron-prebuilt": "^1.2.0",
     "electron-rebuild": "^1.5.11",
@@ -117,7 +117,8 @@
     "linux": {
       "category": "Development",
       "target": [
-        "AppImage"
+        "AppImage",
+        "snap"
       ]
     },
     "nsis": {


### PR DESCRIPTION
I've put together this pull request to add a [snap](https://snapcraft.io) package. I've tested it on Ubuntu 16.04, but it should work just as well on Ubuntu 14.04, Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and `npm run release` on an Ubuntu 16.04 VM with an [appropriate version of node installed](https://github.com/nodesource/distributions) it will create `dist/graphiql-app_VERSION_amd64.snap`.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run:
`sudo snap install --dangerous graphiql-app_VERSION_amd64.snap`. Execute it with `graphiql-app` from the terminal or find it in the desktop launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and https://snapcraft.io/discover. To create the developer account, [sign up here](https://dashboard.snapcraft.io/dev/account/), then [register the "graphiql-app" name](https://dashboard.snapcraft.io/register-snap/?name=graphiql-app).

You'll need the `snapcraft` command to push the snap file to the store.
* If you're on a Mac, you can `brew install snapcraft`
* If you're on Linux, it's `sudo snap install --classic snapcraft`

Then you can push it to the store out with:
`snapcraft push graphiql-app_VERSION_amd64.snap --release stable`