### PR TITLE
Export query for POST body

### DIFF
--- a/app/components/App.js
+++ b/app/components/App.js
@@ -60,6 +60,9 @@ export default class App extends React.Component {
       case 'PREVIOUS_TAB':
         this.gotoPreviousTab();
         break;
+      case 'EXPORT_QUERY':
+        this.exportQuery();
+        break;
       default:
         console.error("No idea how to handle '" + option + "'");
         break;
@@ -138,6 +141,35 @@ export default class App extends React.Component {
     }, () => {
       this.updateLocalStorage();
     });
+  }
+
+  exportQuery() {
+    const queryText = this.graphiql.getQueryEditor().getValue();
+    const variablesText = this.graphiql.getVariableEditor().getValue();
+    const variables = variablesText ? JSON.parse(variablesText) : undefined;
+    const queryObj = {
+      query: queryText,
+      variables
+    };
+    this.copyToClipboard(JSON.stringify(queryObj, null, 2));
+  }
+
+  copyToClipboard(text) {
+    const span = document.createElement('span');
+    span.style.whiteSpace = 'pre';
+    span.textContent = text;
+    const selection = window.getSelection();
+    document.body.appendChild(span);
+  
+    const range = document.createRange();
+    selection.removeAllRanges();
+    range.selectNode(span);
+    selection.addRange(range);
+  
+    document.execCommand('copy');
+  
+    selection.removeAllRanges();
+    span.remove();
   }
 
   getCurrentTab() {
@@ -299,6 +331,7 @@ export default class App extends React.Component {
             // THIS IS THE GROSSEST THING I'VE EVER DONE AND I HATE IT. FIXME ASAP
           }
           <GraphiQL
+            ref={graphiql => this.graphiql = graphiql}
             key={currentTabIndex + currentTab.endpoint + JSON.stringify(currentTab.headers)}
             storage={getStorage(`graphiql:${currentTab.uuid}`)}
             fetcher={this.graphQLFetcher} />

--- a/main.js
+++ b/main.js
@@ -90,6 +90,14 @@ app.on('ready', function() {
         click: function() {
           mainWindow.webContents.send('handleElectronMenuOption', 'CLOSE_TAB');
         }
+      }, {
+        type: 'separator'
+      }, {
+        label: 'Export query (to clipboard)',
+        accelerator: 'Command+E',
+        click: function() {
+          mainWindow.webContents.send('handleElectronMenuOption', 'EXPORT_QUERY');
+        }
       }]
     }, {
       label: 'Edit',
@@ -205,6 +213,14 @@ app.on('ready', function() {
         accelerator: 'Ctrl+W',
         click: function() {
           mainWindow.webContents.send('handleElectronMenuOption', 'CLOSE_TAB');
+        }
+      }, {
+        type: 'separator'
+      }, {
+        label: 'Export query (to clipboard)',
+        accelerator: 'Ctrl+E',
+        click: function() {
+          mainWindow.webContents.send('handleElectronMenuOption', 'EXPORT_QUERY');
         }
       }]
     }, {


### PR DESCRIPTION
Added menu option to export query along with variables to clipboard. It could be used as a body of HTTP POST query.