### PR TITLE
switch to ClientRequest so we have better control

### DIFF
--- a/app/components/App.js
+++ b/app/components/App.js
@@ -3,9 +3,9 @@ import _ from 'lodash';
 import uuid from 'uuid';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import fetch from 'isomorphic-fetch';
 import GraphiQL from 'graphiql/dist';
 import Modal from 'react-modal/lib/index';
+import { ClientRequest } from 'http';
 
 Modal.setAppElement(document.getElementById('react-root'));
 
@@ -160,14 +160,14 @@ export default class App extends React.Component {
     span.textContent = text;
     const selection = window.getSelection();
     document.body.appendChild(span);
-  
+
     const range = document.createRange();
     selection.removeAllRanges();
     range.selectNode(span);
     selection.addRange(range);
-  
+
     document.execCommand('copy');
-  
+
     selection.removeAllRanges();
     span.remove();
   }
@@ -208,31 +208,49 @@ export default class App extends React.Component {
       });
     }
 
-
+    const requestHeaders = Object.assign({}, defaultHeaders, headers);
+    const url = new URL(endpoint);
 
     if (method == "get") {
-      var url = endpoint;
       if (typeof graphQLParams['variables'] === "undefined"){
         graphQLParams['variables'] = "{}";
       }
 
-      url += url.indexOf('?') == -1 ? "?" : "&";
+      const query = encodeURIComponent(graphQLParams['query']);
+      const variables = encodeURIComponent(JSON.stringify(graphQLParams['variables']));
 
-      return fetch(url + "query=" + encodeURIComponent(graphQLParams['query']) + "&variables=" + encodeURIComponent(JSON.stringify(graphQLParams['variables'])), {
-        method: method,
-        credentials: 'include',
-        headers: Object.assign({}, defaultHeaders, headers),
-        body: null
-      }).then(response => response.json())
-        .catch(reason => error);
+      url.search = `query=${query}&variables=${variables}`;
     }
-    return fetch(endpoint, {
-      method: method,
-      credentials: 'include',
-      headers: Object.assign({}, defaultHeaders, headers),
-      body: JSON.stringify(graphQLParams)
-    }).then(response => response.json())
-      .catch(reason => error);
+
+    const request = new ClientRequest({
+      method,
+      protocol: url.protocol,
+      hostname: url.hostname,
+      port: url.port,
+      path: url.pathname + url.search,
+    });
+
+    for (const header in requestHeaders) {
+      request.setHeader(header, requestHeaders[header]);
+    }
+
+    return new Promise((resolve, reject) => {
+      request.on('response', response => {
+        const chunks = [];
+        response.on('data', data => {
+          chunks.push(Buffer.from(data));
+        });
+        response.on('end', end => {
+          resolve(JSON.parse(Buffer.concat(chunks).toString()));
+        });
+      });
+
+      if (method == "get") {
+        request.end();
+      } else {
+        request.end(JSON.stringify(graphQLParams));
+      }
+    })
   }
 
   handleChange(field, eOrKey, e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3300,18 +3300,7 @@
           "integrity": "sha512-+rr4OgeTNrLuJAf09o3USdttEYiXvZshWMkhD6wR9v1ieXH0JM1Q2yT41/cJuJcqiPpSXlM/g3aR+Y5MWQdr0Q==",
           "dev": true,
           "requires": {
-            "7zip-bin-linux": "1.3.1",
-            "7zip-bin-mac": "1.0.1",
-            "7zip-bin-win": "2.1.1"
-          },
-          "dependencies": {
-            "7zip-bin-linux": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/7zip-bin-linux/-/7zip-bin-linux-1.3.1.tgz",
-              "integrity": "sha512-Wv1uEEeHbTiS1+ycpwUxYNuIcyohU6Y6vEqY3NquBkeqy0YhVdsNUGsj0XKSRciHR6LoJSEUuqYUexmws3zH7Q==",
-              "dev": true,
-              "optional": true
-            }
+            "7zip-bin-mac": "1.0.1"
           }
         },
         "7zip-bin-mac": {
@@ -3324,9 +3313,7 @@
         "7zip-bin-win": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/7zip-bin-win/-/7zip-bin-win-2.1.1.tgz",
-          "integrity": "sha512-6VGEW7PXGroTsoI2QW3b0ea95HJmbVBHvfANKLLMzSzFA1zKqVX5ybNuhmeGpf6vA0x8FJTt6twpprDANsY5WQ==",
-          "dev": true,
-          "optional": true
+          "integrity": "sha512-6VGEW7PXGroTsoI2QW3b0ea95HJmbVBHvfANKLLMzSzFA1zKqVX5ybNuhmeGpf6vA0x8FJTt6twpprDANsY5WQ=="
         },
         "ansi-styles": {
           "version": "3.2.0",
@@ -5265,18 +5252,7 @@
           "integrity": "sha512-+rr4OgeTNrLuJAf09o3USdttEYiXvZshWMkhD6wR9v1ieXH0JM1Q2yT41/cJuJcqiPpSXlM/g3aR+Y5MWQdr0Q==",
           "dev": true,
           "requires": {
-            "7zip-bin-linux": "1.3.1",
-            "7zip-bin-mac": "1.0.1",
-            "7zip-bin-win": "2.1.1"
-          },
-          "dependencies": {
-            "7zip-bin-linux": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/7zip-bin-linux/-/7zip-bin-linux-1.3.1.tgz",
-              "integrity": "sha512-Wv1uEEeHbTiS1+ycpwUxYNuIcyohU6Y6vEqY3NquBkeqy0YhVdsNUGsj0XKSRciHR6LoJSEUuqYUexmws3zH7Q==",
-              "dev": true,
-              "optional": true
-            }
+            "7zip-bin-mac": "1.0.1"
           }
         },
         "7zip-bin-mac": {
@@ -5289,9 +5265,7 @@
         "7zip-bin-win": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/7zip-bin-win/-/7zip-bin-win-2.1.1.tgz",
-          "integrity": "sha512-6VGEW7PXGroTsoI2QW3b0ea95HJmbVBHvfANKLLMzSzFA1zKqVX5ybNuhmeGpf6vA0x8FJTt6twpprDANsY5WQ==",
-          "dev": true,
-          "optional": true
+          "integrity": "sha512-6VGEW7PXGroTsoI2QW3b0ea95HJmbVBHvfANKLLMzSzFA1zKqVX5ybNuhmeGpf6vA0x8FJTt6twpprDANsY5WQ=="
         },
         "ansi-align": {
           "version": "2.0.0",
@@ -7077,6 +7051,12 @@
             "tweetnacl": "0.14.5"
           }
         },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7087,12 +7067,6 @@
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
         },
         "stringstream": {
           "version": "0.0.5",
@@ -8849,6 +8823,12 @@
             "tweetnacl": "0.14.5"
           }
         },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -8859,12 +8839,6 @@
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
         },
         "stringstream": {
           "version": "0.0.5",
@@ -10436,6 +10410,15 @@
           "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
           "dev": true
         },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
         "string-editor": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/string-editor/-/string-editor-0.1.2.tgz",
@@ -10454,15 +10437,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
           }
         },
         "stringstream": {
@@ -14410,6 +14384,13 @@
                 }
               }
             },
+            "string_decoder": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.0.1"
+              }
+            },
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
@@ -14417,13 +14398,6 @@
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
                 "strip-ansi": "3.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.0.1"
               }
             },
             "stringstream": {
@@ -16806,6 +16780,15 @@
             "tweetnacl": "0.14.5"
           }
         },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -16831,15 +16814,6 @@
                 "ansi-regex": "3.0.0"
               }
             }
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
           }
         },
         "stringstream": {
@@ -17238,6 +17212,14 @@
       "integrity": "sha1-fWqDlmnKZ5CanbgB1QK8OVzGZpU=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+      "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
+      "dev": true,
+      "requires": {
+        "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+      }
+    },
     "string-width": {
       "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
@@ -17246,14 +17228,6 @@
         "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
         "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
         "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-      }
-    },
-    "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-      "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
-      "dev": true,
-      "requires": {
-        "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
       }
     },
     "stringmap": {
@@ -18782,6 +18756,14 @@
                 }
               }
             },
+            "string_decoder": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "5.0.1"
+              }
+            },
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
@@ -18790,14 +18772,6 @@
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
                 "strip-ansi": "3.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "5.0.1"
               }
             },
             "stringstream": {

--- a/package.json
+++ b/package.json
@@ -32,16 +32,15 @@
   "dependencies": {
     "graphiql": "^0.11.11",
     "graphql": "^0.13.0",
-    "isomorphic-fetch": "^2.1.1",
     "lodash": "^3.10.1",
     "mousetrap": "^1.5.3",
     "object-assign": "^4.0.1",
+    "prop-types": "^15.6.0",
     "radium": "^0.14.1",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-modal": "^2.0.2",
-    "uuid": "^3.1.0",
-    "prop-types": "^15.6.0"
+    "uuid": "^3.1.0"
   },
   "devDependencies": {
     "asar": "^0.13.0",


### PR DESCRIPTION
This PR switches from the [isomorphic-fetch](https://github.com/matthew-andrews/isomorphic-fetch) library to the native [http](https://nodejs.org/api/http.html) and [https](https://nodejs.org/api/https.html) modules to give us more control over request configuration. 

The fetch library operates under the assumption its in the browser which means it doesn't allow certain headers to be set like `Host`, `Cookie` or `User-Agent`. Since this is an electron app, we don't have the same limitations. 

I believe this PR will also resolve #112 and close #62 

/cc @skevy @gjtorikian 