### PR TITLE
ignore unauthorized certs to allow for self-signed certs

### DIFF
--- a/app/components/App.js
+++ b/app/components/App.js
@@ -231,6 +231,7 @@ export default class App extends React.Component {
       port: url.port,
       path: url.pathname + url.search,
       headers: requestHeaders,
+      rejectUnauthorized: false, // avoid problems with self-signed certs
     };
 
     const request = url.protocol === 'https:' ? httpsRequest(requestOptions) : httpRequest(requestOptions);


### PR DESCRIPTION
I played around with this a little bit, but I think this is the cleanest option to support self-signed certificates. 

This should resolve #118 

/cc @gjtorikian @joshmanders 