### PR TITLE
Add Linux installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A light, Electron-based wrapper around GraphiQL.
 
 Provides a tabbed interface for editing and testing GraphQL queries/mutations with GraphiQL.
 
-#### Installation
+#### macOS installation
 
 If you have [Homebrew](http://brew.sh/) installed on macOS:
 
@@ -16,6 +16,18 @@ brew cask install graphiql
 ```
 
 Alternately, download the binary from the [Releases](https://github.com/skevy/graphiql-app/releases) tab.
+
+#### Linux installation
+
+The graphiql-app uses the [AppImage](https://appimage.org/) format for its Linux version. You download it from the  [Electron app directory](https://electronjs.org/apps/graphiql) (click the "Download for Linux"-button) or from the [Releases](https://github.com/skevy/graphiql-app/releases) tab.
+
+Either way, you will get a `.AppImage` binary. Put it in a safe place and make it executable:
+
+```
+chmod +x graphiql-app-0.7.2-x86_64.AppImage
+```
+
+Then simply execute the app. It will ask whether to add shortcuts to your desktop and menus for easy access in the future.
 
 #### Getting started developing
 


### PR DESCRIPTION
This adds a section to the readme concerning the AppImage binary and how to install it on Linux.

See #91 