### PR TITLE
Add in the GraphiQL Explorer

### DIFF
--- a/app/components/App.js
+++ b/app/components/App.js
@@ -4,6 +4,8 @@ import uuid from 'uuid';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import GraphiQL from 'graphiql/dist';
+import GraphiQLExplorer from "graphiql-explorer";
+import GraphiQLEditor from "./GraphiQLEditor.js";
 import Modal from 'react-modal/lib/index';
 import { request as httpRequest } from 'http';
 import { request as httpsRequest } from 'https';
@@ -357,7 +359,7 @@ export default class App extends React.Component {
           {
             // THIS IS THE GROSSEST THING I'VE EVER DONE AND I HATE IT. FIXME ASAP
           }
-          <GraphiQL
+          <GraphiQLEditor
             ref={graphiql => this.graphiql = graphiql}
             key={currentTabIndex + currentTab.endpoint + JSON.stringify(currentTab.headers)}
             storage={getStorage(`graphiql:${currentTab.uuid}`)}

--- a/app/components/GraphiQLEditor.js
+++ b/app/components/GraphiQLEditor.js
@@ -1,0 +1,147 @@
+import React, { Component } from "react";
+import GraphiQL from "graphiql";
+import GraphiQLExplorer from "graphiql-explorer";
+import { buildClientSchema, getIntrospectionQuery, parse } from "graphql";
+
+import "graphiql/graphiql.css";
+
+class App extends Component {
+  _graphiql: GraphiQL;
+
+  constructor(props) {
+    super(props);
+    const explorerIsOpen = JSON.parse(this.props.storage.getItem("graphiql:explorerIsOpen") || "false");
+    const firstQuery = ((JSON.parse(this.props.storage.getItem("graphiql:queries") || "{}")["queries"]||[])[0] || {}).query;
+    this.state = { schema: null, query: firstQuery, explorerIsOpen: explorerIsOpen};
+  }
+
+  componentDidMount() {
+    this.props.fetcher({
+      query: getIntrospectionQuery()
+    }).then(result => {
+      const editor = this._graphiql.getQueryEditor();
+      editor.setOption("extraKeys", {
+        ...(editor.options.extraKeys || {}),
+        "Shift-Alt-LeftClick": this._handleInspectOperation
+      });
+
+      if (result.data) {
+        this.setState({ schema: buildClientSchema(result.data) });
+      };
+    });
+  }
+
+  _handleInspectOperation = (
+    cm,
+    mousePos
+  ) => {
+    const parsedQuery = parse(this.state.query || "");
+
+    if (!parsedQuery) {
+      console.error("Couldn't parse query document");
+      return null;
+    }
+
+    var token = cm.getTokenAt(mousePos);
+    var start = { line: mousePos.line, ch: token.start };
+    var end = { line: mousePos.line, ch: token.end };
+    var relevantMousePos = {
+      start: cm.indexFromPos(start),
+      end: cm.indexFromPos(end)
+    };
+
+    var position = relevantMousePos;
+
+    var def = parsedQuery.definitions.find(definition => {
+      if (!definition.loc) {
+        console.log("Missing location information for definition");
+        return false;
+      }
+
+      const { start, end } = definition.loc;
+      return start <= position.start && end >= position.end;
+    });
+
+    if (!def) {
+      console.error(
+        "Unable to find definition corresponding to mouse position"
+      );
+      return null;
+    }
+
+    var operationKind =
+      def.kind === "OperationDefinition"
+        ? def.operation
+        : def.kind === "FragmentDefinition"
+        ? "fragment"
+        : "unknown";
+
+    var operationName =
+      def.kind === "OperationDefinition" && !!def.name
+        ? def.name.value
+        : def.kind === "FragmentDefinition" && !!def.name
+        ? def.name.value
+        : "unknown";
+
+    var selector = `.graphiql-explorer-root #${operationKind}-${operationName}`;
+
+    var el = document.querySelector(selector);
+    el && el.scrollIntoView();
+  }
+
+  _handleEditQuery = (query) => this.setState({ query });
+
+  _handleToggleExplorer = () => {
+    const explorerIsOpen = !this.state.explorerIsOpen;
+    this.props.storage.setItem("graphiql:explorerIsOpen", JSON.stringify(!this.state.explorerIsOpen));
+    this.setState({ explorerIsOpen: explorerIsOpen });
+  };
+
+  render() {
+    console.log("State stuff: ", this.state, this.props);
+    const { query, schema } = this.state;
+    console.log("GraphiQL state: ", this.state);
+    return (
+      <div className="graphiql-container">
+        <GraphiQLExplorer
+          schema={schema}
+          query={query}
+          onEdit={this._handleEditQuery}
+          onRunOperation={operationName =>
+            this._graphiql.handleRunQuery(operationName)
+          }
+          explorerIsOpen={this.state.explorerIsOpen}
+          onToggleExplorer={this._handleToggleExplorer}
+        />
+        <GraphiQL
+          ref={ref => (this._graphiql = ref)}
+          fetcher={this.props.fetcher}
+          schema={schema}
+          onEditQuery={this._handleEditQuery}
+          storage={this.props.storage}
+          query={this.state.query}
+        >
+          <GraphiQL.Toolbar>
+            <GraphiQL.Button
+              onClick={() => this._graphiql.handlePrettifyQuery()}
+              label="Prettify"
+              title="Prettify Query (Shift-Ctrl-P)"
+            />
+            <GraphiQL.Button
+              onClick={() => this._graphiql.handleToggleHistory()}
+              label="History"
+              title="Show History"
+            />
+            <GraphiQL.Button
+              onClick={this._handleToggleExplorer}
+              label="Explorer"
+              title="Toggle Explorer"
+            />
+          </GraphiQL.Toolbar>
+        </GraphiQL>
+      </div>
+    );
+  }
+}
+
+export default App;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,79 @@
 {
   "name": "graphiql-app",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/graphql": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.11.7.tgz",
-      "integrity": "sha512-+6UMNcBeLR/G/yMIFXVA6XJhfDlPO7x6cb7ooiyN12Q6GE1l3KbupZoWBMV2Uw3F2q+i+IiaHx9rIKwLADw+7A=="
+    "7zip-bin": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-4.1.0.tgz",
+      "integrity": "sha512-AsnBZN3a8/JcNt+KPkGGODaA4c7l3W5+WpeKgGSbstSLxqWtTXqd1ieJGBQ8IFCtRg8DmmKUcSkIkUc0A4p3YA==",
+      "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.102",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.102.tgz",
-      "integrity": "sha512-k/SxycYmVc6sYo6kzm8cABHcbMs9MXn6jYsja1hLvZ/x9e31VHRRn+1UzWdpv6doVchphvKaOsZ0VTqbF7zvNg=="
+    "@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true
+    },
+    "@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "dev": true,
+      "requires": {
+        "defer-to-connect": "^1.0.1"
+      }
+    },
+    "@types/debug": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
+      "dev": true
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
     },
     "acorn": {
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
       "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
     },
+    "ajv": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        }
+      }
+    },
+    "ajv-keywords": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+      "dev": true
+    },
     "align-text": {
-      "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-        "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "alter": {
@@ -33,128 +81,96 @@
       "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
       "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
       "requires": {
-        "stable": "0.1.6"
+        "stable": "~0.1.3"
+      }
+    },
+    "ansi-align": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
+      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.0.0"
       }
     },
     "ansi-regex": {
-      "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
-      "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
-    "app-package-builder": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/app-package-builder/-/app-package-builder-1.3.1.tgz",
-      "integrity": "sha512-TnKHgkO0zW1x9b1bDAJSPNx9FljH21GaG8gF7uAn134GvR4hVO98h+zQ9lDYKV4uyW+F6eKrWKAUhUupD2sNuQ==",
+    "app-builder-bin": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-2.7.1.tgz",
+      "integrity": "sha512-ubIBeiL9XysjMW4HETBKxj3DC8ika6dGyC0vftPc0kZwGh1iXQ5bycsjoAqY/3t3BBEEIg0VruicvBaUl1pOSQ==",
+      "dev": true
+    },
+    "app-builder-lib": {
+      "version": "20.44.4",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-20.44.4.tgz",
+      "integrity": "sha512-1K1xfrhyqDgnibwyuYMgvfwGilGLMF31YwOUJ8IXreyjRef9lUjWW+BZuBXqk4Uqd0C0EYPjhofgpuN0WoAQ+A==",
       "dev": true,
       "requires": {
-        "bluebird-lst": "1.0.5",
-        "builder-util": "3.0.13",
-        "builder-util-runtime": "2.4.0",
-        "fs-extra-p": "4.4.4",
-        "int64-buffer": "0.1.9",
-        "js-yaml": "3.10.0",
-        "rabin-bindings": "1.7.3"
+        "7zip-bin": "~4.1.0",
+        "app-builder-bin": "2.7.1",
+        "async-exit-hook": "^2.0.1",
+        "bluebird-lst": "^1.0.9",
+        "builder-util": "10.1.2",
+        "builder-util-runtime": "8.2.5",
+        "chromium-pickle-js": "^0.2.0",
+        "debug": "^4.1.1",
+        "ejs": "^2.6.2",
+        "electron-osx-sign": "0.4.11",
+        "electron-publish": "20.44.4",
+        "fs-extra-p": "^8.0.2",
+        "hosted-git-info": "^2.7.1",
+        "is-ci": "^2.0.0",
+        "isbinaryfile": "^4.0.1",
+        "js-yaml": "^3.13.1",
+        "lazy-val": "^1.0.4",
+        "minimatch": "^3.0.4",
+        "normalize-package-data": "^2.5.0",
+        "plist": "^3.0.1",
+        "read-config-file": "3.2.2",
+        "sanitize-filename": "^1.6.1",
+        "semver": "^6.1.1",
+        "temp-file": "^3.3.3"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-          "dev": true
-        },
-        "bluebird-lst": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.5.tgz",
-          "integrity": "sha512-Ey0bDNys5qpYPhZ/oQ9vOEvD0TYQDTILMXWP2iGfvMg7rSDde+oV4aQQgqRH+CvBFNz2BSDQnPGMUl6LKBUUQA==",
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "bluebird": "3.5.1"
+            "brace-expansion": "^1.1.7"
           }
         },
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.1"
-          }
-        },
-        "fs-extra-p": {
-          "version": "4.4.4",
-          "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.4.4.tgz",
-          "integrity": "sha512-zHsMNJWhXD184QfHKEIFSQSgAFNV7v9J+Nt2XpaLZp2nTz6WxZNV+R4G2uYeGeLTMaKvUZiqGKrH/4iFCupcUA==",
-          "dev": true,
-          "requires": {
-            "bluebird-lst": "1.0.5",
-            "fs-extra": "4.0.2"
-          }
-        },
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-          "dev": true,
-          "requires": {
-            "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-            "esprima": "4.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-          }
-        },
-        "universalify": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-          "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
     },
-    "aproba": {
-      "version": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-      "integrity": "sha1-RcZikJTeTpb2k+9+q3SuB5wkD8E=",
-      "dev": true
-    },
-    "are-we-there-yet": {
-      "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-      "dev": true,
-      "requires": {
-        "delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
-      }
-    },
     "argparse": {
-      "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-find-index": {
-      "version": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "asar": {
       "version": "0.13.0",
@@ -162,13 +178,13 @@
       "integrity": "sha1-3zPdnQG/+EJGTQ2fCVdA1KYq+xQ=",
       "dev": true,
       "requires": {
-        "chromium-pickle-js": "0.2.0",
-        "commander": "2.11.0",
-        "cuint": "0.2.2",
-        "glob": "6.0.4",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "mksnapshot": "0.3.1",
+        "chromium-pickle-js": "^0.2.0",
+        "commander": "^2.9.0",
+        "cuint": "^0.2.1",
+        "glob": "^6.0.4",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^0.5.0",
+        "mksnapshot": "^0.3.0",
         "tmp": "0.0.28"
       },
       "dependencies": {
@@ -184,10 +200,10 @@
           "integrity": "sha1-Pa+ai2ciEpn9ro2C0RftjmyAJEs=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "0.3.1",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "json-schema-traverse": "^0.3.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "asn1": {
@@ -233,7 +249,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "binary": {
@@ -242,8 +258,8 @@
           "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
           "dev": true,
           "requires": {
-            "buffers": "0.1.1",
-            "chainsaw": "0.1.0"
+            "buffers": "~0.1.1",
+            "chainsaw": "~0.1.0"
           }
         },
         "boom": {
@@ -252,7 +268,7 @@
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         },
         "brace-expansion": {
@@ -261,7 +277,7 @@
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -283,7 +299,7 @@
           "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
           "dev": true,
           "requires": {
-            "traverse": "0.3.9"
+            "traverse": ">=0.3.0 <0.4"
           }
         },
         "chromium-pickle-js": {
@@ -304,7 +320,7 @@
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "commander": {
@@ -331,7 +347,7 @@
           "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
           "dev": true,
           "requires": {
-            "boom": "5.2.0"
+            "boom": "5.x.x"
           },
           "dependencies": {
             "boom": {
@@ -340,7 +356,7 @@
               "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
               "dev": true,
               "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.x.x"
               }
             }
           }
@@ -357,7 +373,7 @@
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "decompress-zip": {
@@ -366,12 +382,12 @@
           "integrity": "sha1-rjvLfjTGWHmt/nfhnDD4ZgK0vbA=",
           "dev": true,
           "requires": {
-            "binary": "0.3.0",
-            "graceful-fs": "4.1.11",
-            "mkpath": "0.1.0",
-            "nopt": "3.0.6",
-            "q": "1.5.1",
-            "readable-stream": "1.1.14",
+            "binary": "^0.3.0",
+            "graceful-fs": "^4.1.3",
+            "mkpath": "^0.1.0",
+            "nopt": "^3.0.1",
+            "q": "^1.1.2",
+            "readable-stream": "^1.1.8",
             "touch": "0.0.3"
           }
         },
@@ -388,7 +404,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "extend": {
@@ -415,9 +431,9 @@
           "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs-extra": {
@@ -426,11 +442,11 @@
           "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "fs.realpath": {
@@ -445,7 +461,7 @@
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "glob": {
@@ -454,11 +470,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -479,8 +495,8 @@
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "dev": true,
           "requires": {
-            "ajv": "5.2.4",
-            "har-schema": "2.0.0"
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
           }
         },
         "hawk": {
@@ -489,10 +505,10 @@
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
           "dev": true,
           "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.0.2"
+            "boom": "4.x.x",
+            "cryptiles": "3.x.x",
+            "hoek": "4.x.x",
+            "sntp": "2.x.x"
           }
         },
         "hoek": {
@@ -507,9 +523,9 @@
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "inflight": {
@@ -518,8 +534,8 @@
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -571,7 +587,7 @@
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -586,7 +602,7 @@
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.6"
           }
         },
         "jsonify": {
@@ -613,7 +629,7 @@
           "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.9"
           }
         },
         "mime-db": {
@@ -628,7 +644,7 @@
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "dev": true,
           "requires": {
-            "mime-db": "1.30.0"
+            "mime-db": "~1.30.0"
           }
         },
         "minimatch": {
@@ -637,7 +653,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -669,7 +685,7 @@
           "requires": {
             "decompress-zip": "0.3.0",
             "fs-extra": "0.26.7",
-            "request": "2.83.0"
+            "request": "^2.79.0"
           }
         },
         "nopt": {
@@ -678,7 +694,7 @@
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
-            "abbrev": "1.1.1"
+            "abbrev": "1"
           }
         },
         "oauth-sign": {
@@ -693,7 +709,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-tmpdir": {
@@ -738,10 +754,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "request": {
@@ -750,28 +766,28 @@
           "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           }
         },
         "rimraf": {
@@ -780,7 +796,7 @@
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           },
           "dependencies": {
             "glob": {
@@ -789,12 +805,12 @@
               "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "dev": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             }
           }
@@ -811,7 +827,7 @@
           "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         },
         "sshpk": {
@@ -820,14 +836,14 @@
           "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
           "dev": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
           }
         },
         "string_decoder": {
@@ -848,7 +864,7 @@
           "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2"
+            "os-tmpdir": "~1.0.1"
           }
         },
         "touch": {
@@ -857,7 +873,7 @@
           "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
           "dev": true,
           "requires": {
-            "nopt": "1.0.10"
+            "nopt": "~1.0.10"
           },
           "dependencies": {
             "nopt": {
@@ -866,7 +882,7 @@
               "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
               "dev": true,
               "requires": {
-                "abbrev": "1.1.1"
+                "abbrev": "1"
               }
             }
           }
@@ -877,7 +893,7 @@
           "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
           "dev": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "traverse": {
@@ -892,7 +908,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -908,9 +924,9 @@
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
+            "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
+            "extsprintf": "^1.2.0"
           }
         },
         "wrappy": {
@@ -922,14 +938,17 @@
       }
     },
     "asn1": {
-      "version": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-      "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
     },
     "assert-plus": {
-      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-      "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "ast-traverse": {
       "version": "0.1.1",
@@ -942,8 +961,9 @@
       "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
     },
     "async": {
-      "version": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
     "async-exit-hook": {
@@ -952,10 +972,26 @@
       "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
       "dev": true
     },
-    "aws-sign2": {
-      "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-      "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "author-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz",
+      "integrity": "sha1-0IiFvmubv5Q5/gh8dihyRfCoFFA=",
       "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "babel-core": {
       "version": "6.26.0",
@@ -963,25 +999,25 @@
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-        "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-        "slash": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "debug": "^2.6.8",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.7",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.6"
       },
       "dependencies": {
         "babel-code-frame": {
@@ -990,9 +1026,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-generator": {
@@ -1001,14 +1037,14 @@
           "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
           "dev": true,
           "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.4",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-            "trim-right": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.6",
+            "trim-right": "^1.0.1"
           }
         },
         "babel-helpers": {
@@ -1017,8 +1053,8 @@
           "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-messages": {
@@ -1027,7 +1063,7 @@
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-register": {
@@ -1036,13 +1072,13 @@
           "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
           "dev": true,
           "requires": {
-            "babel-core": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "core-js": "2.5.1",
-            "home-or-tmp": "2.0.0",
-            "lodash": "4.17.4",
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "source-map-support": "0.4.18"
+            "babel-core": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "core-js": "^2.5.0",
+            "home-or-tmp": "^2.0.0",
+            "lodash": "^4.17.4",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.4.15"
           }
         },
         "babel-template": {
@@ -1051,11 +1087,11 @@
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -1064,15 +1100,15 @@
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           }
         },
         "babel-types": {
@@ -1081,10 +1117,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "babylon": {
@@ -1114,7 +1150,7 @@
           "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "globals": {
@@ -1129,8 +1165,8 @@
           "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
           "dev": true,
           "requires": {
-            "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-            "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.1"
           }
         },
         "invariant": {
@@ -1139,7 +1175,7 @@
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "dev": true,
           "requires": {
-            "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+            "loose-envify": "^1.0.0"
           }
         },
         "js-tokens": {
@@ -1172,7 +1208,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
+            "brace-expansion": "^1.1.7"
           }
         },
         "ms": {
@@ -1187,7 +1223,7 @@
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
-            "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+            "is-finite": "^1.0.0"
           }
         },
         "source-map-support": {
@@ -1196,7 +1232,7 @@
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "dev": true,
           "requires": {
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            "source-map": "^0.5.6"
           }
         },
         "to-fast-properties": {
@@ -1213,10 +1249,10 @@
       "integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
       "dev": true,
       "requires": {
-        "find-cache-dir": "0.1.1",
-        "loader-utils": "0.2.17",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
+        "find-cache-dir": "^0.1.1",
+        "loader-utils": "^0.2.16",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^4.0.1"
       },
       "dependencies": {
         "big.js": {
@@ -1243,9 +1279,9 @@
           "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "dev": true,
           "requires": {
-            "commondir": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pkg-dir": "1.0.0"
+            "commondir": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pkg-dir": "^1.0.0"
           }
         },
         "find-up": {
@@ -1254,8 +1290,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "json5": {
@@ -1270,10 +1306,10 @@
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "dev": true,
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
           }
         },
         "minimist": {
@@ -1297,7 +1333,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pinkie": {
@@ -1312,7 +1348,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "pkg-dir": {
@@ -1321,7 +1357,7 @@
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           }
         }
       }
@@ -1366,7 +1402,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
       "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
       "requires": {
-        "lodash": "3.10.1"
+        "lodash": "^3.9.3"
       }
     },
     "babel-plugin-react-constant-elements": {
@@ -1400,7 +1436,7 @@
       "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-undeclared-variables-check": {
@@ -1408,7 +1444,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
       "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
       "requires": {
-        "leven": "1.0.2"
+        "leven": "^1.0.2"
       }
     },
     "babel-plugin-undefined-to-void": {
@@ -1422,36 +1458,36 @@
       "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.5.1",
-        "invariant": "2.2.2",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^2.1.2",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
       },
       "dependencies": {
         "babel-code-frame": {
@@ -1460,9 +1496,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -1471,9 +1507,9 @@
           "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
           "dev": true,
           "requires": {
-            "babel-helper-explode-assignable-expression": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-explode-assignable-expression": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-call-delegate": {
@@ -1482,10 +1518,10 @@
           "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
           "dev": true,
           "requires": {
-            "babel-helper-hoist-variables": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-hoist-variables": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-define-map": {
@@ -1494,10 +1530,10 @@
           "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
           "dev": true,
           "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.4"
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-helper-explode-assignable-expression": {
@@ -1506,9 +1542,9 @@
           "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-function-name": {
@@ -1517,11 +1553,11 @@
           "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
           "dev": true,
           "requires": {
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-get-function-arity": {
@@ -1530,8 +1566,8 @@
           "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-hoist-variables": {
@@ -1540,8 +1576,8 @@
           "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-optimise-call-expression": {
@@ -1550,8 +1586,8 @@
           "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-regex": {
@@ -1560,9 +1596,9 @@
           "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-helper-remap-async-to-generator": {
@@ -1571,11 +1607,11 @@
           "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
           "dev": true,
           "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-replace-supers": {
@@ -1584,12 +1620,12 @@
           "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
           "dev": true,
           "requires": {
-            "babel-helper-optimise-call-expression": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-optimise-call-expression": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-messages": {
@@ -1598,7 +1634,7 @@
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-check-es2015-constants": {
@@ -1607,7 +1643,7 @@
           "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-syntax-async-functions": {
@@ -1634,9 +1670,9 @@
           "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
           "dev": true,
           "requires": {
-            "babel-helper-remap-async-to-generator": "6.24.1",
-            "babel-plugin-syntax-async-functions": "6.13.0",
-            "babel-runtime": "6.26.0"
+            "babel-helper-remap-async-to-generator": "^6.24.1",
+            "babel-plugin-syntax-async-functions": "^6.8.0",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-arrow-functions": {
@@ -1645,7 +1681,7 @@
           "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1654,7 +1690,7 @@
           "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-block-scoping": {
@@ -1663,11 +1699,11 @@
           "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-plugin-transform-es2015-classes": {
@@ -1676,15 +1712,15 @@
           "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
           "dev": true,
           "requires": {
-            "babel-helper-define-map": "6.26.0",
-            "babel-helper-function-name": "6.24.1",
-            "babel-helper-optimise-call-expression": "6.24.1",
-            "babel-helper-replace-supers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-define-map": "^6.24.1",
+            "babel-helper-function-name": "^6.24.1",
+            "babel-helper-optimise-call-expression": "^6.24.1",
+            "babel-helper-replace-supers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-computed-properties": {
@@ -1693,8 +1729,8 @@
           "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-destructuring": {
@@ -1703,7 +1739,7 @@
           "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-duplicate-keys": {
@@ -1712,8 +1748,8 @@
           "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-for-of": {
@@ -1722,7 +1758,7 @@
           "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-function-name": {
@@ -1731,9 +1767,9 @@
           "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
           "dev": true,
           "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-literals": {
@@ -1742,7 +1778,7 @@
           "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-modules-amd": {
@@ -1751,9 +1787,9 @@
           "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
           "dev": true,
           "requires": {
-            "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1762,10 +1798,10 @@
           "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
           "dev": true,
           "requires": {
-            "babel-plugin-transform-strict-mode": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-plugin-transform-strict-mode": "^6.24.1",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-types": "^6.26.0"
           }
         },
         "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1774,9 +1810,9 @@
           "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
           "dev": true,
           "requires": {
-            "babel-helper-hoist-variables": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-helper-hoist-variables": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-modules-umd": {
@@ -1785,9 +1821,9 @@
           "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
           "dev": true,
           "requires": {
-            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-object-super": {
@@ -1796,8 +1832,8 @@
           "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
           "dev": true,
           "requires": {
-            "babel-helper-replace-supers": "6.24.1",
-            "babel-runtime": "6.26.0"
+            "babel-helper-replace-supers": "^6.24.1",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-parameters": {
@@ -1806,12 +1842,12 @@
           "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
           "dev": true,
           "requires": {
-            "babel-helper-call-delegate": "6.24.1",
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-call-delegate": "^6.24.1",
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1820,8 +1856,8 @@
           "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-spread": {
@@ -1830,7 +1866,7 @@
           "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-sticky-regex": {
@@ -1839,9 +1875,9 @@
           "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
           "dev": true,
           "requires": {
-            "babel-helper-regex": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-template-literals": {
@@ -1850,7 +1886,7 @@
           "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1859,7 +1895,7 @@
           "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-unicode-regex": {
@@ -1868,9 +1904,9 @@
           "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
           "dev": true,
           "requires": {
-            "babel-helper-regex": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "regexpu-core": "2.0.0"
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "regexpu-core": "^2.0.0"
           }
         },
         "babel-plugin-transform-exponentiation-operator": {
@@ -1879,9 +1915,9 @@
           "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
           "dev": true,
           "requires": {
-            "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-            "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-            "babel-runtime": "6.26.0"
+            "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+            "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-regenerator": {
@@ -1890,7 +1926,7 @@
           "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
           "dev": true,
           "requires": {
-            "regenerator-transform": "0.10.1"
+            "regenerator-transform": "^0.10.0"
           }
         },
         "babel-plugin-transform-strict-mode": {
@@ -1899,8 +1935,8 @@
           "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-template": {
@@ -1909,11 +1945,11 @@
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -1922,15 +1958,15 @@
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           }
         },
         "babel-types": {
@@ -1939,10 +1975,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "babylon": {
@@ -1957,8 +1993,8 @@
           "integrity": "sha512-jAvM2ku7YDJ+leAq3bFH1DE0Ylw+F+EQDq4GkqZfgPEqpWYw9ofQH85uKSB9r3Tv7XDbfqVtE+sdvKJW7IlPJA==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30000749",
-            "electron-to-chromium": "1.3.27"
+            "caniuse-lite": "^1.0.30000744",
+            "electron-to-chromium": "^1.3.24"
           }
         },
         "caniuse-lite": {
@@ -1994,7 +2030,7 @@
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "dev": true,
           "requires": {
-            "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+            "loose-envify": "^1.0.0"
           }
         },
         "js-tokens": {
@@ -2021,9 +2057,9 @@
           "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
+            "babel-runtime": "^6.18.0",
+            "babel-types": "^6.19.0",
+            "private": "^0.1.6"
           }
         },
         "regexpu-core": {
@@ -2032,9 +2068,9 @@
           "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
           "dev": true,
           "requires": {
-            "regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-            "regjsgen": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-            "regjsparser": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
           }
         },
         "to-fast-properties": {
@@ -2051,7 +2087,7 @@
       "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-flow-strip-types": "6.22.0"
+        "babel-plugin-transform-flow-strip-types": "^6.22.0"
       },
       "dependencies": {
         "babel-plugin-syntax-flow": {
@@ -2066,8 +2102,8 @@
           "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
           "dev": true,
           "requires": {
-            "babel-plugin-syntax-flow": "6.18.0",
-            "babel-runtime": "6.26.0"
+            "babel-plugin-syntax-flow": "^6.18.0",
+            "babel-runtime": "^6.22.0"
           }
         }
       }
@@ -2078,12 +2114,12 @@
       "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-plugin-transform-react-display-name": "6.25.0",
-        "babel-plugin-transform-react-jsx": "6.24.1",
-        "babel-plugin-transform-react-jsx-self": "6.22.0",
-        "babel-plugin-transform-react-jsx-source": "6.22.0",
-        "babel-preset-flow": "6.23.0"
+        "babel-plugin-syntax-jsx": "^6.3.13",
+        "babel-plugin-transform-react-display-name": "^6.23.0",
+        "babel-plugin-transform-react-jsx": "^6.24.1",
+        "babel-plugin-transform-react-jsx-self": "^6.22.0",
+        "babel-plugin-transform-react-jsx-source": "^6.22.0",
+        "babel-preset-flow": "^6.23.0"
       },
       "dependencies": {
         "babel-helper-builder-react-jsx": {
@@ -2092,9 +2128,9 @@
           "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "esutils": "2.0.2"
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "esutils": "^2.0.2"
           }
         },
         "babel-plugin-syntax-jsx": {
@@ -2109,7 +2145,7 @@
           "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-react-jsx": {
@@ -2118,9 +2154,9 @@
           "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
           "dev": true,
           "requires": {
-            "babel-helper-builder-react-jsx": "6.26.0",
-            "babel-plugin-syntax-jsx": "6.18.0",
-            "babel-runtime": "6.26.0"
+            "babel-helper-builder-react-jsx": "^6.24.1",
+            "babel-plugin-syntax-jsx": "^6.8.0",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-react-jsx-self": {
@@ -2129,8 +2165,8 @@
           "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
           "dev": true,
           "requires": {
-            "babel-plugin-syntax-jsx": "6.18.0",
-            "babel-runtime": "6.26.0"
+            "babel-plugin-syntax-jsx": "^6.8.0",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-react-jsx-source": {
@@ -2139,8 +2175,8 @@
           "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
           "dev": true,
           "requires": {
-            "babel-plugin-syntax-jsx": "6.18.0",
-            "babel-runtime": "6.26.0"
+            "babel-plugin-syntax-jsx": "^6.8.0",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-types": {
@@ -2149,10 +2185,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "esutils": {
@@ -2181,9 +2217,9 @@
       "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-class-constructor-call": "6.24.1",
-        "babel-plugin-transform-export-extensions": "6.22.0",
-        "babel-preset-stage-2": "6.24.1"
+        "babel-plugin-transform-class-constructor-call": "^6.24.1",
+        "babel-plugin-transform-export-extensions": "^6.22.0",
+        "babel-preset-stage-2": "^6.24.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2204,9 +2240,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-messages": {
@@ -2215,7 +2251,7 @@
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-syntax-class-constructor-call": {
@@ -2236,9 +2272,9 @@
           "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
           "dev": true,
           "requires": {
-            "babel-plugin-syntax-class-constructor-call": "6.18.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-plugin-syntax-class-constructor-call": "^6.18.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-export-extensions": {
@@ -2247,8 +2283,8 @@
           "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
           "dev": true,
           "requires": {
-            "babel-plugin-syntax-export-extensions": "6.13.0",
-            "babel-runtime": "6.26.0"
+            "babel-plugin-syntax-export-extensions": "^6.8.0",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-template": {
@@ -2257,11 +2293,11 @@
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -2270,15 +2306,15 @@
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           }
         },
         "babel-types": {
@@ -2287,10 +2323,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "babylon": {
@@ -2305,11 +2341,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "debug": {
@@ -2345,7 +2381,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "invariant": {
@@ -2354,7 +2390,7 @@
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "js-tokens": {
@@ -2375,7 +2411,7 @@
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "ms": {
@@ -2390,7 +2426,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -2413,10 +2449,10 @@
       "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "6.18.0",
-        "babel-plugin-transform-class-properties": "6.24.1",
-        "babel-plugin-transform-decorators": "6.24.1",
-        "babel-preset-stage-3": "6.24.1"
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-plugin-transform-class-properties": "^6.24.1",
+        "babel-plugin-transform-decorators": "^6.24.1",
+        "babel-preset-stage-3": "^6.24.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2437,9 +2473,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-helper-bindify-decorators": {
@@ -2448,9 +2484,9 @@
           "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-explode-class": {
@@ -2459,10 +2495,10 @@
           "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
           "dev": true,
           "requires": {
-            "babel-helper-bindify-decorators": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-bindify-decorators": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-function-name": {
@@ -2471,11 +2507,11 @@
           "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
           "dev": true,
           "requires": {
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-get-function-arity": {
@@ -2484,8 +2520,8 @@
           "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-messages": {
@@ -2494,7 +2530,7 @@
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-syntax-class-properties": {
@@ -2521,10 +2557,10 @@
           "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
           "dev": true,
           "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-plugin-syntax-class-properties": "6.13.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-helper-function-name": "^6.24.1",
+            "babel-plugin-syntax-class-properties": "^6.8.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-decorators": {
@@ -2533,11 +2569,11 @@
           "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
           "dev": true,
           "requires": {
-            "babel-helper-explode-class": "6.24.1",
-            "babel-plugin-syntax-decorators": "6.13.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-explode-class": "^6.24.1",
+            "babel-plugin-syntax-decorators": "^6.13.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-template": {
@@ -2546,11 +2582,11 @@
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -2559,15 +2595,15 @@
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           }
         },
         "babel-types": {
@@ -2576,10 +2612,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "babylon": {
@@ -2594,11 +2630,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "debug": {
@@ -2634,7 +2670,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "invariant": {
@@ -2643,7 +2679,7 @@
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "js-tokens": {
@@ -2664,7 +2700,7 @@
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "ms": {
@@ -2679,7 +2715,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -2702,11 +2738,11 @@
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "dev": true,
       "requires": {
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-generator-functions": "6.24.1",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-object-rest-spread": "6.26.0"
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-generator-functions": "^6.24.1",
+        "babel-plugin-transform-async-to-generator": "^6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
+        "babel-plugin-transform-object-rest-spread": "^6.22.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2727,9 +2763,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -2738,9 +2774,9 @@
           "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
           "dev": true,
           "requires": {
-            "babel-helper-explode-assignable-expression": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-explode-assignable-expression": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-explode-assignable-expression": {
@@ -2749,9 +2785,9 @@
           "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-function-name": {
@@ -2760,11 +2796,11 @@
           "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
           "dev": true,
           "requires": {
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-get-function-arity": {
@@ -2773,8 +2809,8 @@
           "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-remap-async-to-generator": {
@@ -2783,11 +2819,11 @@
           "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
           "dev": true,
           "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-messages": {
@@ -2796,7 +2832,7 @@
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-syntax-async-functions": {
@@ -2835,9 +2871,9 @@
           "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
           "dev": true,
           "requires": {
-            "babel-helper-remap-async-to-generator": "6.24.1",
-            "babel-plugin-syntax-async-generators": "6.13.0",
-            "babel-runtime": "6.26.0"
+            "babel-helper-remap-async-to-generator": "^6.24.1",
+            "babel-plugin-syntax-async-generators": "^6.5.0",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-async-to-generator": {
@@ -2846,9 +2882,9 @@
           "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
           "dev": true,
           "requires": {
-            "babel-helper-remap-async-to-generator": "6.24.1",
-            "babel-plugin-syntax-async-functions": "6.13.0",
-            "babel-runtime": "6.26.0"
+            "babel-helper-remap-async-to-generator": "^6.24.1",
+            "babel-plugin-syntax-async-functions": "^6.8.0",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-exponentiation-operator": {
@@ -2857,9 +2893,9 @@
           "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
           "dev": true,
           "requires": {
-            "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-            "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-            "babel-runtime": "6.26.0"
+            "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+            "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-object-rest-spread": {
@@ -2868,8 +2904,8 @@
           "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
           "dev": true,
           "requires": {
-            "babel-plugin-syntax-object-rest-spread": "6.13.0",
-            "babel-runtime": "6.26.0"
+            "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+            "babel-runtime": "^6.26.0"
           }
         },
         "babel-template": {
@@ -2878,11 +2914,11 @@
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -2891,15 +2927,15 @@
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           }
         },
         "babel-types": {
@@ -2908,10 +2944,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "babylon": {
@@ -2926,11 +2962,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "debug": {
@@ -2966,7 +3002,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "invariant": {
@@ -2975,7 +3011,7 @@
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "js-tokens": {
@@ -2996,7 +3032,7 @@
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "ms": {
@@ -3011,7 +3047,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -3034,8 +3070,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
         "core-js": {
@@ -3058,50 +3094,54 @@
       "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0="
     },
     "balanced-match": {
-      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
       "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
     },
-    "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
       "dev": true
     },
-    "bl": {
-      "version": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-      "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "big.js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+      "dev": true
+    },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
       "dev": true,
       "requires": {
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-          }
-        },
-        "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
       }
     },
     "bluebird": {
-      "version": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
       "dev": true
+    },
+    "bluebird-lst": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
+      "integrity": "sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.5"
+      }
     },
     "body-parser": {
       "version": "1.18.2",
@@ -3110,15 +3150,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "http-errors": "1.6.2",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.15"
+        "type-is": "~1.6.15"
       },
       "dependencies": {
         "bytes": {
@@ -3163,7 +3203,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": "1.4.0"
+            "statuses": ">= 1.3.1 < 2"
           }
         },
         "iconv-lite": {
@@ -3196,7 +3236,7 @@
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "dev": true,
           "requires": {
-            "mime-db": "1.30.0"
+            "mime-db": "~1.30.0"
           }
         },
         "ms": {
@@ -3239,25 +3279,71 @@
           "dev": true,
           "requires": {
             "media-typer": "0.3.0",
-            "mime-types": "2.1.17"
+            "mime-types": "~2.1.15"
           }
         }
       }
     },
-    "boom": {
-      "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+    "boxen": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
+      "integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
       "dev": true,
       "requires": {
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+        "ansi-align": "^3.0.0",
+        "camelcase": "^5.3.1",
+        "chalk": "^2.4.2",
+        "cli-boxes": "^2.2.0",
+        "string-width": "^3.0.0",
+        "term-size": "^1.2.0",
+        "type-fest": "^0.3.0",
+        "widest-line": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "brace-expansion": {
-      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
       "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
       "requires": {
-        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+        "balanced-match": "^0.4.1",
+        "concat-map": "0.0.1"
       }
     },
     "breakable": {
@@ -3265,187 +3351,79 @@
       "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
       "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME="
     },
-    "buffer-shims": {
-      "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "dev": true,
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "dev": true
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
       "dev": true
     },
     "builder-util": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-3.0.13.tgz",
-      "integrity": "sha512-fJSZR170B4jBz5RGBvaIv5VvYBjknlh4bb+x0DxchjYk+D5Z8e3mSLQNPAvwt3v0e1qheWc+pNM8518nnxOXDg==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-10.1.2.tgz",
+      "integrity": "sha512-LQMh36Cg0r4ZfKqNlaUclndS/IXxZ3OdCgmXvw1vdP3QwYT2NkyE7LfMikAFIHpXOs6zsVH+iW+Fe/AX1jfFag==",
       "dev": true,
       "requires": {
-        "7zip-bin": "2.2.7",
-        "bluebird-lst": "1.0.5",
-        "builder-util-runtime": "2.4.0",
-        "chalk": "2.1.0",
-        "debug": "3.1.0",
-        "fs-extra-p": "4.4.4",
-        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-        "is-ci": "1.0.10",
-        "js-yaml": "3.10.0",
-        "lazy-val": "1.0.2",
-        "node-emoji": "1.8.1",
-        "semver": "5.4.1",
-        "source-map-support": "0.5.0",
-        "stat-mode": "0.2.2",
-        "temp-file": "2.0.3",
-        "tunnel-agent": "0.6.0"
+        "7zip-bin": "~4.1.0",
+        "@types/debug": "^4.1.4",
+        "app-builder-bin": "2.7.1",
+        "bluebird-lst": "^1.0.9",
+        "builder-util-runtime": "^8.2.5",
+        "chalk": "^2.4.2",
+        "debug": "^4.1.1",
+        "fs-extra-p": "^8.0.2",
+        "is-ci": "^2.0.0",
+        "js-yaml": "^3.13.1",
+        "source-map-support": "^0.5.12",
+        "stat-mode": "^0.3.0",
+        "temp-file": "^3.3.3"
       },
       "dependencies": {
-        "7zip-bin": {
-          "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-2.2.7.tgz",
-          "integrity": "sha512-+rr4OgeTNrLuJAf09o3USdttEYiXvZshWMkhD6wR9v1ieXH0JM1Q2yT41/cJuJcqiPpSXlM/g3aR+Y5MWQdr0Q==",
-          "dev": true,
-          "requires": {
-            "7zip-bin-mac": "1.0.1"
-          }
-        },
-        "7zip-bin-mac": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/7zip-bin-mac/-/7zip-bin-mac-1.0.1.tgz",
-          "integrity": "sha1-Pmh3i78JJq3GgVlCcHRQXUdVXAI=",
-          "dev": true,
-          "optional": true
-        },
-        "7zip-bin-win": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/7zip-bin-win/-/7zip-bin-win-2.1.1.tgz",
-          "integrity": "sha512-6VGEW7PXGroTsoI2QW3b0ea95HJmbVBHvfANKLLMzSzFA1zKqVX5ybNuhmeGpf6vA0x8FJTt6twpprDANsY5WQ=="
-        },
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz"
-          }
-        },
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-          "dev": true
-        },
-        "bluebird-lst": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.5.tgz",
-          "integrity": "sha512-Ey0bDNys5qpYPhZ/oQ9vOEvD0TYQDTILMXWP2iGfvMg7rSDde+oV4aQQgqRH+CvBFNz2BSDQnPGMUl6LKBUUQA==",
-          "dev": true,
-          "requires": {
-            "bluebird": "3.5.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
-        },
-        "ci-info": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
-          "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.1"
-          }
-        },
-        "fs-extra-p": {
-          "version": "4.4.4",
-          "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.4.4.tgz",
-          "integrity": "sha512-zHsMNJWhXD184QfHKEIFSQSgAFNV7v9J+Nt2XpaLZp2nTz6WxZNV+R4G2uYeGeLTMaKvUZiqGKrH/4iFCupcUA==",
-          "dev": true,
-          "requires": {
-            "bluebird-lst": "1.0.5",
-            "fs-extra": "4.0.2"
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "is-ci": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
-          "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
-          "dev": true,
-          "requires": {
-            "ci-info": "1.1.1"
-          }
-        },
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-          "dev": true,
-          "requires": {
-            "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-            "esprima": "4.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "node-emoji": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
-          "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
-          "dev": true,
-          "requires": {
-            "lodash.toarray": "4.4.0"
-          }
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true
         },
         "source-map": {
           "version": "0.6.1",
@@ -3454,173 +3432,103 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
-          "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
+          "version": "0.5.13",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+          "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
           "dev": true,
           "requires": {
-            "source-map": "0.6.1"
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
           }
-        },
-        "stat-mode": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
-          "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
-          "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^3.0.0"
           }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
-          }
-        },
-        "universalify": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-          "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-          "dev": true
         }
       }
     },
     "builder-util-runtime": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-2.4.0.tgz",
-      "integrity": "sha512-35PskRowZnDnqJ6zbGSZ+ijndHPan2l56tF9n+FHMNmZnSQ69aw5eXWQDxyMlKKVwt/lF6dFGWhyRtsBmtDL7g==",
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.2.5.tgz",
+      "integrity": "sha512-YILT+YUlxrE3yNB6mDC1tF+Q24mr1LSYdjP5U861jbBeDZfvy1/VPDzW3boMVrDtzYnDnvkYrzLJnoh6TXA75w==",
       "dev": true,
       "requires": {
-        "bluebird-lst": "1.0.5",
-        "debug": "3.1.0",
-        "fs-extra-p": "4.4.4",
-        "sax": "1.2.4"
+        "bluebird-lst": "^1.0.9",
+        "debug": "^4.1.1",
+        "fs-extra-p": "^8.0.2",
+        "sax": "^1.2.4"
+      }
+    },
+    "cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "dev": true,
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-          "dev": true
-        },
-        "bluebird-lst": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.5.tgz",
-          "integrity": "sha512-Ey0bDNys5qpYPhZ/oQ9vOEvD0TYQDTILMXWP2iGfvMg7rSDde+oV4aQQgqRH+CvBFNz2BSDQnPGMUl6LKBUUQA==",
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
           "dev": true,
           "requires": {
-            "bluebird": "3.5.1"
+            "pump": "^3.0.0"
           }
         },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.1"
-          }
-        },
-        "fs-extra-p": {
-          "version": "4.4.4",
-          "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.4.4.tgz",
-          "integrity": "sha512-zHsMNJWhXD184QfHKEIFSQSgAFNV7v9J+Nt2XpaLZp2nTz6WxZNV+R4G2uYeGeLTMaKvUZiqGKrH/4iFCupcUA==",
-          "dev": true,
-          "requires": {
-            "bluebird-lst": "1.0.5",
-            "fs-extra": "4.0.2"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-          }
-        },
-        "ms": {
+        "lowercase-keys": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-          "dev": true
-        },
-        "universalify": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-          "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
           "dev": true
         }
       }
     },
-    "builtin-modules": {
-      "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
-    },
     "camelcase": {
-      "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
     },
     "camelcase-keys": {
-      "version": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true,
       "requires": {
-        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-        "map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
-          "version": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
         }
       }
     },
-    "capture-stack-trace": {
-      "version": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-      "dev": true
-    },
     "caseless": {
-      "version": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-      "integrity": "sha1-t7Zc5r8UE4hlOc/VM/CzDv+pz4g=",
-      "dev": true
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "center-align": {
-      "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
-        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chai": {
@@ -3629,9 +3537,9 @@
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.2",
-        "deep-eql": "0.1.3",
-        "type-detect": "1.0.0"
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
       },
       "dependencies": {
         "assertion-error": {
@@ -3671,83 +3579,113 @@
       "integrity": "sha1-CdekApCKpw39vq1T5YU/x50+8hw=",
       "dev": true
     },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "dev": true,
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
+      }
+    },
     "chalk": {
-      "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
-    "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+    "chromium-pickle-js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+      "integrity": "sha1-BKEGZywYsIWrd02YPfo+oTjyIgU=",
+      "dev": true
+    },
+    "ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
+    },
+    "cli-boxes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
+      "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
       "dev": true
     },
     "cliui": {
-      "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "requires": {
-        "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-        "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
       }
     },
-    "co": {
-      "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
     },
     "code-point-at": {
-      "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "codemirror": {
-      "version": "5.34.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.34.0.tgz",
-      "integrity": "sha512-7ke9DJB350sChxq1skTmotVZsJtiJo1ihC41rq8IyOMZv47Z1AQygoevWHs0PJTw2eBphmB7gA3AbPrVrnfwPw=="
+      "version": "5.48.4",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.48.4.tgz",
+      "integrity": "sha512-pUhZXDQ6qXSpWdwlgAwHEkd4imA0kf83hINmUEzJpmG80T/XLtDDEzZo8f6PQLuRCcUQhmzqqIo3ZPTRaWByRA=="
     },
     "codemirror-graphql": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-0.6.12.tgz",
-      "integrity": "sha512-7YP956JubbWkmk9QqKy62CZgdGbEulHNJkz2/aUDTpsE1KrQtRrT9WzStJaxAOEX2k4wUOpojUX2ItPxa69kFA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-0.7.1.tgz",
+      "integrity": "sha512-HtHXMJAn6iGJYpijkzi3IlqWIdGrB6V0RqJ607yffJTCKk/OgaNtdLOb8hZJyEtHfkw7PZDaKybMAVCi6ScWSQ==",
       "requires": {
-        "graphql-language-service-interface": "1.0.18",
-        "graphql-language-service-parser": "0.1.14"
+        "graphql-language-service-interface": "^1.3.2",
+        "graphql-language-service-parser": "^1.2.2"
       }
     },
     "color-convert": {
-      "version": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
-        "color-name": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
-      "version": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
-      "integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "combined-stream": {
-      "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-      "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-      "dev": true,
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
-        "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
-      "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "requires": {
-        "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "commoner": {
@@ -3755,15 +3693,15 @@
       "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
       "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
       "requires": {
-        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-        "detective": "4.5.0",
-        "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-        "q": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-        "recast": "0.11.23"
+        "commander": "^2.5.0",
+        "detective": "^4.3.1",
+        "glob": "^5.0.15",
+        "graceful-fs": "^4.1.2",
+        "iconv-lite": "^0.4.5",
+        "mkdirp": "^0.5.0",
+        "private": "^0.1.6",
+        "q": "^1.1.2",
+        "recast": "^0.11.17"
       },
       "dependencies": {
         "recast": {
@@ -3772,48 +3710,119 @@
           "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
           "requires": {
             "ast-types": "0.9.6",
-            "esprima": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-            "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-            "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            "esprima": "~3.1.0",
+            "private": "~0.1.5",
+            "source-map": "~0.5.0"
           }
         }
       }
     },
-    "concat-map": {
-      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "console-control-strings": {
-      "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+    "compare-version": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+      "integrity": "sha1-AWLsLZNR9d3VmpICy6k1NmpyUIA=",
       "dev": true
     },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "configstore": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
+      "integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
+      "dev": true,
+      "requires": {
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      }
+    },
     "convert-source-map": {
-      "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
       "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
       "dev": true
     },
     "core-util-is": {
-      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-fetch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-1.1.1.tgz",
-      "integrity": "sha512-+VJE04+UfxxmBfcnmAu/lKor53RUCx/1ilOti4p+JgrnLQ4AZZIRoe2OEd76VaHyWQmQxqKnV+TaqjHC4r0HWw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.2.tgz",
+      "integrity": "sha1-pH/09/xxLauo9qaVoRyUhEDUVyM=",
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
+        "node-fetch": "2.1.2",
+        "whatwg-fetch": "2.0.4"
       }
     },
-    "cryptiles": {
-      "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
+    },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
     },
     "css-loader": {
       "version": "0.19.0",
@@ -3821,14 +3830,14 @@
       "integrity": "sha1-c4PbaiD8xCOVutpLirwlwnNVd7g=",
       "dev": true,
       "requires": {
-        "css-selector-tokenizer": "0.5.4",
-        "cssnano": "3.10.0",
-        "loader-utils": "0.2.17",
-        "postcss": "5.2.18",
+        "css-selector-tokenizer": "^0.5.1",
+        "cssnano": ">=2.6.1 <4",
+        "loader-utils": "~0.2.2",
+        "postcss": "^5.0.6",
         "postcss-modules-extract-imports": "1.0.0-beta2",
         "postcss-modules-local-by-default": "1.0.0-beta1",
         "postcss-modules-scope": "1.0.0-beta2",
-        "source-list-map": "0.1.8"
+        "source-list-map": "^0.1.4"
       },
       "dependencies": {
         "alphanum-sort": {
@@ -3855,7 +3864,7 @@
           "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
           "dev": true,
           "requires": {
-            "sprintf-js": "1.0.3"
+            "sprintf-js": "~1.0.2"
           }
         },
         "autoprefixer": {
@@ -3864,12 +3873,12 @@
           "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
           "dev": true,
           "requires": {
-            "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000749",
-            "normalize-range": "0.1.2",
-            "num2fraction": "1.2.2",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.0"
+            "browserslist": "^1.7.6",
+            "caniuse-db": "^1.0.30000634",
+            "normalize-range": "^0.1.2",
+            "num2fraction": "^1.2.2",
+            "postcss": "^5.2.16",
+            "postcss-value-parser": "^3.2.3"
           }
         },
         "balanced-match": {
@@ -3890,8 +3899,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000749",
-            "electron-to-chromium": "1.3.27"
+            "caniuse-db": "^1.0.30000639",
+            "electron-to-chromium": "^1.2.7"
           }
         },
         "caniuse-api": {
@@ -3900,10 +3909,10 @@
           "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
           "dev": true,
           "requires": {
-            "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000749",
-            "lodash.memoize": "4.1.2",
-            "lodash.uniq": "4.5.0"
+            "browserslist": "^1.3.6",
+            "caniuse-db": "^1.0.30000529",
+            "lodash.memoize": "^4.1.2",
+            "lodash.uniq": "^4.5.0"
           }
         },
         "caniuse-db": {
@@ -3918,11 +3927,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -3939,7 +3948,7 @@
           "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3"
+            "chalk": "^1.1.3"
           }
         },
         "clone": {
@@ -3954,7 +3963,7 @@
           "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
           "dev": true,
           "requires": {
-            "q": "1.5.1"
+            "q": "^1.1.2"
           }
         },
         "color": {
@@ -3963,9 +3972,9 @@
           "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
           "dev": true,
           "requires": {
-            "clone": "1.0.2",
-            "color-convert": "1.9.0",
-            "color-string": "0.3.0"
+            "clone": "^1.0.2",
+            "color-convert": "^1.3.0",
+            "color-string": "^0.3.0"
           }
         },
         "color-convert": {
@@ -3974,7 +3983,7 @@
           "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
           "dev": true,
           "requires": {
-            "color-name": "1.1.3"
+            "color-name": "^1.1.1"
           }
         },
         "color-name": {
@@ -3989,7 +3998,7 @@
           "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
           "dev": true,
           "requires": {
-            "color-name": "1.1.3"
+            "color-name": "^1.0.0"
           }
         },
         "colormin": {
@@ -3998,9 +4007,9 @@
           "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
           "dev": true,
           "requires": {
-            "color": "0.11.4",
+            "color": "^0.11.0",
             "css-color-names": "0.0.4",
-            "has": "1.0.1"
+            "has": "^1.0.1"
           }
         },
         "colors": {
@@ -4021,8 +4030,8 @@
           "integrity": "sha1-E5uv00o1/QwUKEhwSeBpnm9qLCE=",
           "dev": true,
           "requires": {
-            "cssesc": "0.1.0",
-            "fastparse": "1.1.1"
+            "cssesc": "^0.1.0",
+            "fastparse": "^1.1.1"
           }
         },
         "cssesc": {
@@ -4037,38 +4046,38 @@
           "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
           "dev": true,
           "requires": {
-            "autoprefixer": "6.7.7",
-            "decamelize": "1.2.0",
-            "defined": "1.0.0",
-            "has": "1.0.1",
-            "object-assign": "4.1.1",
-            "postcss": "5.2.18",
-            "postcss-calc": "5.3.1",
-            "postcss-colormin": "2.2.2",
-            "postcss-convert-values": "2.6.1",
-            "postcss-discard-comments": "2.0.4",
-            "postcss-discard-duplicates": "2.1.0",
-            "postcss-discard-empty": "2.1.0",
-            "postcss-discard-overridden": "0.1.1",
-            "postcss-discard-unused": "2.2.3",
-            "postcss-filter-plugins": "2.0.2",
-            "postcss-merge-idents": "2.1.7",
-            "postcss-merge-longhand": "2.0.2",
-            "postcss-merge-rules": "2.1.2",
-            "postcss-minify-font-values": "1.0.5",
-            "postcss-minify-gradients": "1.0.5",
-            "postcss-minify-params": "1.2.2",
-            "postcss-minify-selectors": "2.1.1",
-            "postcss-normalize-charset": "1.1.1",
-            "postcss-normalize-url": "3.0.8",
-            "postcss-ordered-values": "2.2.3",
-            "postcss-reduce-idents": "2.4.0",
-            "postcss-reduce-initial": "1.0.1",
-            "postcss-reduce-transforms": "1.0.4",
-            "postcss-svgo": "2.1.6",
-            "postcss-unique-selectors": "2.0.2",
-            "postcss-value-parser": "3.3.0",
-            "postcss-zindex": "2.2.0"
+            "autoprefixer": "^6.3.1",
+            "decamelize": "^1.1.2",
+            "defined": "^1.0.0",
+            "has": "^1.0.1",
+            "object-assign": "^4.0.1",
+            "postcss": "^5.0.14",
+            "postcss-calc": "^5.2.0",
+            "postcss-colormin": "^2.1.8",
+            "postcss-convert-values": "^2.3.4",
+            "postcss-discard-comments": "^2.0.4",
+            "postcss-discard-duplicates": "^2.0.1",
+            "postcss-discard-empty": "^2.0.1",
+            "postcss-discard-overridden": "^0.1.1",
+            "postcss-discard-unused": "^2.2.1",
+            "postcss-filter-plugins": "^2.0.0",
+            "postcss-merge-idents": "^2.1.5",
+            "postcss-merge-longhand": "^2.0.1",
+            "postcss-merge-rules": "^2.0.3",
+            "postcss-minify-font-values": "^1.0.2",
+            "postcss-minify-gradients": "^1.0.1",
+            "postcss-minify-params": "^1.0.4",
+            "postcss-minify-selectors": "^2.0.4",
+            "postcss-normalize-charset": "^1.1.0",
+            "postcss-normalize-url": "^3.0.7",
+            "postcss-ordered-values": "^2.1.0",
+            "postcss-reduce-idents": "^2.2.2",
+            "postcss-reduce-initial": "^1.0.0",
+            "postcss-reduce-transforms": "^1.0.3",
+            "postcss-svgo": "^2.1.1",
+            "postcss-unique-selectors": "^2.0.2",
+            "postcss-value-parser": "^3.2.3",
+            "postcss-zindex": "^2.0.1"
           }
         },
         "csso": {
@@ -4077,8 +4086,8 @@
           "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
           "dev": true,
           "requires": {
-            "clap": "1.2.3",
-            "source-map": "0.5.7"
+            "clap": "^1.0.9",
+            "source-map": "^0.5.3"
           }
         },
         "decamelize": {
@@ -4141,7 +4150,7 @@
           "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
           "dev": true,
           "requires": {
-            "function-bind": "1.1.1"
+            "function-bind": "^1.0.2"
           }
         },
         "has-ansi": {
@@ -4150,7 +4159,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "has-flag": {
@@ -4189,7 +4198,7 @@
           "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
           "dev": true,
           "requires": {
-            "html-comment-regex": "1.1.1"
+            "html-comment-regex": "^1.1.0"
           }
         },
         "js-base64": {
@@ -4204,8 +4213,8 @@
           "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "2.7.3"
+            "argparse": "^1.0.7",
+            "esprima": "^2.6.0"
           }
         },
         "json5": {
@@ -4220,10 +4229,10 @@
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "dev": true,
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
           }
         },
         "lodash.memoize": {
@@ -4277,10 +4286,10 @@
           "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
           "dev": true,
           "requires": {
-            "object-assign": "4.1.1",
-            "prepend-http": "1.0.4",
-            "query-string": "4.3.4",
-            "sort-keys": "1.1.2"
+            "object-assign": "^4.0.1",
+            "prepend-http": "^1.0.0",
+            "query-string": "^4.1.0",
+            "sort-keys": "^1.0.0"
           }
         },
         "num2fraction": {
@@ -4295,10 +4304,10 @@
           "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "postcss-calc": {
@@ -4307,9 +4316,9 @@
           "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18",
-            "postcss-message-helpers": "2.0.0",
-            "reduce-css-calc": "1.3.0"
+            "postcss": "^5.0.2",
+            "postcss-message-helpers": "^2.0.0",
+            "reduce-css-calc": "^1.2.6"
           }
         },
         "postcss-colormin": {
@@ -4318,9 +4327,9 @@
           "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
           "dev": true,
           "requires": {
-            "colormin": "1.1.2",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.0"
+            "colormin": "^1.0.5",
+            "postcss": "^5.0.13",
+            "postcss-value-parser": "^3.2.3"
           }
         },
         "postcss-convert-values": {
@@ -4329,8 +4338,8 @@
           "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.0"
+            "postcss": "^5.0.11",
+            "postcss-value-parser": "^3.1.2"
           }
         },
         "postcss-discard-comments": {
@@ -4339,7 +4348,7 @@
           "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18"
+            "postcss": "^5.0.14"
           }
         },
         "postcss-discard-duplicates": {
@@ -4348,7 +4357,7 @@
           "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18"
+            "postcss": "^5.0.4"
           }
         },
         "postcss-discard-empty": {
@@ -4357,7 +4366,7 @@
           "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18"
+            "postcss": "^5.0.14"
           }
         },
         "postcss-discard-overridden": {
@@ -4366,7 +4375,7 @@
           "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18"
+            "postcss": "^5.0.16"
           }
         },
         "postcss-discard-unused": {
@@ -4375,8 +4384,8 @@
           "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18",
-            "uniqs": "2.0.0"
+            "postcss": "^5.0.14",
+            "uniqs": "^2.0.0"
           }
         },
         "postcss-filter-plugins": {
@@ -4385,8 +4394,8 @@
           "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18",
-            "uniqid": "4.1.1"
+            "postcss": "^5.0.4",
+            "uniqid": "^4.0.0"
           }
         },
         "postcss-merge-idents": {
@@ -4395,9 +4404,9 @@
           "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
           "dev": true,
           "requires": {
-            "has": "1.0.1",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.0"
+            "has": "^1.0.1",
+            "postcss": "^5.0.10",
+            "postcss-value-parser": "^3.1.1"
           }
         },
         "postcss-merge-longhand": {
@@ -4406,7 +4415,7 @@
           "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18"
+            "postcss": "^5.0.4"
           }
         },
         "postcss-merge-rules": {
@@ -4415,11 +4424,11 @@
           "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
           "dev": true,
           "requires": {
-            "browserslist": "1.7.7",
-            "caniuse-api": "1.6.1",
-            "postcss": "5.2.18",
-            "postcss-selector-parser": "2.2.3",
-            "vendors": "1.0.1"
+            "browserslist": "^1.5.2",
+            "caniuse-api": "^1.5.2",
+            "postcss": "^5.0.4",
+            "postcss-selector-parser": "^2.2.2",
+            "vendors": "^1.0.0"
           }
         },
         "postcss-message-helpers": {
@@ -4434,9 +4443,9 @@
           "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
           "dev": true,
           "requires": {
-            "object-assign": "4.1.1",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.0"
+            "object-assign": "^4.0.1",
+            "postcss": "^5.0.4",
+            "postcss-value-parser": "^3.0.2"
           }
         },
         "postcss-minify-gradients": {
@@ -4445,8 +4454,8 @@
           "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.0"
+            "postcss": "^5.0.12",
+            "postcss-value-parser": "^3.3.0"
           }
         },
         "postcss-minify-params": {
@@ -4455,10 +4464,10 @@
           "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
           "dev": true,
           "requires": {
-            "alphanum-sort": "1.0.2",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.0",
-            "uniqs": "2.0.0"
+            "alphanum-sort": "^1.0.1",
+            "postcss": "^5.0.2",
+            "postcss-value-parser": "^3.0.2",
+            "uniqs": "^2.0.0"
           }
         },
         "postcss-minify-selectors": {
@@ -4467,10 +4476,10 @@
           "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
           "dev": true,
           "requires": {
-            "alphanum-sort": "1.0.2",
-            "has": "1.0.1",
-            "postcss": "5.2.18",
-            "postcss-selector-parser": "2.2.3"
+            "alphanum-sort": "^1.0.2",
+            "has": "^1.0.1",
+            "postcss": "^5.0.14",
+            "postcss-selector-parser": "^2.0.0"
           }
         },
         "postcss-modules-extract-imports": {
@@ -4479,7 +4488,7 @@
           "integrity": "sha1-8dNTPuo/553/qXojccyRY5NAHcU=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18"
+            "postcss": "^5.0.4"
           }
         },
         "postcss-modules-local-by-default": {
@@ -4488,8 +4497,8 @@
           "integrity": "sha1-ibOtZfZplzOGgElTlIqtI7czDV8=",
           "dev": true,
           "requires": {
-            "css-selector-tokenizer": "0.5.4",
-            "postcss": "5.2.18"
+            "css-selector-tokenizer": "^0.5.1",
+            "postcss": "^5.0.4"
           }
         },
         "postcss-modules-scope": {
@@ -4498,8 +4507,8 @@
           "integrity": "sha1-dq+LAAjt5ka7nbZ14nvE7jqgRLw=",
           "dev": true,
           "requires": {
-            "css-selector-tokenizer": "0.5.4",
-            "postcss": "5.2.18"
+            "css-selector-tokenizer": "^0.5.0",
+            "postcss": "^5.0.4"
           }
         },
         "postcss-normalize-charset": {
@@ -4508,7 +4517,7 @@
           "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18"
+            "postcss": "^5.0.5"
           }
         },
         "postcss-normalize-url": {
@@ -4517,10 +4526,10 @@
           "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
           "dev": true,
           "requires": {
-            "is-absolute-url": "2.1.0",
-            "normalize-url": "1.9.1",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.0"
+            "is-absolute-url": "^2.0.0",
+            "normalize-url": "^1.4.0",
+            "postcss": "^5.0.14",
+            "postcss-value-parser": "^3.2.3"
           }
         },
         "postcss-ordered-values": {
@@ -4529,8 +4538,8 @@
           "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.0"
+            "postcss": "^5.0.4",
+            "postcss-value-parser": "^3.0.1"
           }
         },
         "postcss-reduce-idents": {
@@ -4539,8 +4548,8 @@
           "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.0"
+            "postcss": "^5.0.4",
+            "postcss-value-parser": "^3.0.2"
           }
         },
         "postcss-reduce-initial": {
@@ -4549,7 +4558,7 @@
           "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
           "dev": true,
           "requires": {
-            "postcss": "5.2.18"
+            "postcss": "^5.0.4"
           }
         },
         "postcss-reduce-transforms": {
@@ -4558,9 +4567,9 @@
           "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
           "dev": true,
           "requires": {
-            "has": "1.0.1",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.0"
+            "has": "^1.0.1",
+            "postcss": "^5.0.8",
+            "postcss-value-parser": "^3.0.1"
           }
         },
         "postcss-selector-parser": {
@@ -4569,9 +4578,9 @@
           "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
           "dev": true,
           "requires": {
-            "flatten": "1.0.2",
-            "indexes-of": "1.0.1",
-            "uniq": "1.0.1"
+            "flatten": "^1.0.2",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         },
         "postcss-svgo": {
@@ -4580,10 +4589,10 @@
           "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
           "dev": true,
           "requires": {
-            "is-svg": "2.1.0",
-            "postcss": "5.2.18",
-            "postcss-value-parser": "3.3.0",
-            "svgo": "0.7.2"
+            "is-svg": "^2.0.0",
+            "postcss": "^5.0.14",
+            "postcss-value-parser": "^3.2.3",
+            "svgo": "^0.7.0"
           }
         },
         "postcss-unique-selectors": {
@@ -4592,9 +4601,9 @@
           "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
           "dev": true,
           "requires": {
-            "alphanum-sort": "1.0.2",
-            "postcss": "5.2.18",
-            "uniqs": "2.0.0"
+            "alphanum-sort": "^1.0.1",
+            "postcss": "^5.0.4",
+            "uniqs": "^2.0.0"
           }
         },
         "postcss-value-parser": {
@@ -4609,9 +4618,9 @@
           "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
           "dev": true,
           "requires": {
-            "has": "1.0.1",
-            "postcss": "5.2.18",
-            "uniqs": "2.0.0"
+            "has": "^1.0.1",
+            "postcss": "^5.0.4",
+            "uniqs": "^2.0.0"
           }
         },
         "prepend-http": {
@@ -4632,8 +4641,8 @@
           "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
           "dev": true,
           "requires": {
-            "object-assign": "4.1.1",
-            "strict-uri-encode": "1.1.0"
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
           }
         },
         "reduce-css-calc": {
@@ -4642,9 +4651,9 @@
           "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
           "dev": true,
           "requires": {
-            "balanced-match": "0.4.2",
-            "math-expression-evaluator": "1.2.17",
-            "reduce-function-call": "1.0.2"
+            "balanced-match": "^0.4.2",
+            "math-expression-evaluator": "^1.2.14",
+            "reduce-function-call": "^1.0.1"
           }
         },
         "reduce-function-call": {
@@ -4653,7 +4662,7 @@
           "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
           "dev": true,
           "requires": {
-            "balanced-match": "0.4.2"
+            "balanced-match": "^0.4.2"
           }
         },
         "sax": {
@@ -4668,7 +4677,7 @@
           "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
           "dev": true,
           "requires": {
-            "is-plain-obj": "1.1.0"
+            "is-plain-obj": "^1.0.0"
           }
         },
         "source-list-map": {
@@ -4701,7 +4710,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -4710,7 +4719,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         },
         "svgo": {
@@ -4719,13 +4728,13 @@
           "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
           "dev": true,
           "requires": {
-            "coa": "1.0.4",
-            "colors": "1.1.2",
-            "csso": "2.3.2",
-            "js-yaml": "3.7.0",
-            "mkdirp": "0.5.1",
-            "sax": "1.2.4",
-            "whet.extend": "0.9.9"
+            "coa": "~1.0.1",
+            "colors": "~1.1.2",
+            "csso": "~2.3.1",
+            "js-yaml": "~3.7.0",
+            "mkdirp": "~0.5.1",
+            "sax": "~1.2.1",
+            "whet.extend": "~0.9.9"
           }
         },
         "uniq": {
@@ -4740,7 +4749,7 @@
           "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
           "dev": true,
           "requires": {
-            "macaddress": "0.2.8"
+            "macaddress": "^0.2.8"
           }
         },
         "uniqs": {
@@ -4763,30 +4772,80 @@
         }
       }
     },
-    "ctype": {
-      "version": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
+    "cuint": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
       "dev": true
     },
     "currently-unhandled": {
-      "version": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "requires": {
-        "array-find-index": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
-      "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "decompress-zip": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.2.tgz",
+      "integrity": "sha512-Ab1QY4LrWMrUuo53lLnmGOby7v8ryqxJ+bKibKSiPisx+25mhut1dScVBXAYx14i/PqSrFZvR2FRRazhLbvL+g==",
+      "dev": true,
+      "requires": {
+        "binary": "^0.3.0",
+        "graceful-fs": "^4.1.3",
+        "mkpath": "^0.1.0",
+        "nopt": "^3.0.1",
+        "q": "^1.1.2",
+        "readable-stream": "^1.1.8",
+        "touch": "0.0.3"
+      }
+    },
     "deep-extend": {
-      "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-      "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
+    "defer-to-connect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
+      "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==",
       "dev": true
     },
     "defined": {
-      "version": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
     "defs": {
@@ -4794,16 +4853,16 @@
       "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
       "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
       "requires": {
-        "alter": "0.2.0",
-        "ast-traverse": "0.1.1",
-        "breakable": "1.0.0",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "simple-fmt": "0.1.0",
-        "simple-is": "0.2.0",
-        "stringmap": "0.2.2",
-        "stringset": "0.2.1",
-        "tryor": "0.1.2",
-        "yargs": "3.27.0"
+        "alter": "~0.2.0",
+        "ast-traverse": "~0.1.1",
+        "breakable": "~1.0.0",
+        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+        "simple-fmt": "~0.1.0",
+        "simple-is": "~0.2.0",
+        "stringmap": "~0.2.2",
+        "stringset": "~0.2.1",
+        "tryor": "~0.1.2",
+        "yargs": "~3.27.0"
       },
       "dependencies": {
         "esprima-fb": {
@@ -4816,7 +4875,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+            "lcid": "^1.0.0"
           }
         },
         "yargs": {
@@ -4824,12 +4883,12 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
           "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
           "requires": {
-            "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-            "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "os-locale": "1.4.0",
-            "window-size": "0.1.4",
-            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+            "camelcase": "^1.2.1",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
+            "os-locale": "^1.4.0",
+            "window-size": "^0.1.2",
+            "y18n": "^3.2.0"
           }
         }
       }
@@ -4840,13 +4899,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       },
       "dependencies": {
         "array-union": {
@@ -4855,7 +4914,7 @@
           "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
           "dev": true,
           "requires": {
-            "array-uniq": "1.0.3"
+            "array-uniq": "^1.0.1"
           }
         },
         "array-uniq": {
@@ -4882,7 +4941,7 @@
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -4904,12 +4963,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globby": {
@@ -4918,12 +4977,12 @@
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "inflight": {
@@ -4932,8 +4991,8 @@
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -4954,7 +5013,7 @@
           "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
           "dev": true,
           "requires": {
-            "is-path-inside": "1.0.0"
+            "is-path-inside": "^1.0.0"
           }
         },
         "is-path-inside": {
@@ -4963,7 +5022,7 @@
           "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
           "dev": true,
           "requires": {
-            "path-is-inside": "1.0.2"
+            "path-is-inside": "^1.0.1"
           }
         },
         "minimatch": {
@@ -4972,7 +5031,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "once": {
@@ -4981,7 +5040,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "path-is-absolute": {
@@ -5014,7 +5073,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "rimraf": {
@@ -5023,7 +5082,7 @@
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "wrappy": {
@@ -5035,23 +5094,18 @@
       }
     },
     "delayed-stream": {
-      "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-      "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
-      "dev": true
-    },
-    "delegates": {
-      "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "detect-indent": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
       "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
       "requires": {
-        "get-stdin": "4.0.1",
-        "minimist": "1.2.0",
-        "repeating": "1.1.3"
+        "get-stdin": "^4.0.1",
+        "minimist": "^1.1.0",
+        "repeating": "^1.1.0"
       },
       "dependencies": {
         "get-stdin": {
@@ -5071,1105 +5125,127 @@
       "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
       "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
       "requires": {
-        "acorn": "4.0.13",
-        "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+        "acorn": "^4.0.3",
+        "defined": "^1.0.0"
       }
     },
     "dmg-builder": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-2.1.3.tgz",
-      "integrity": "sha512-3H0BNx62NzhTX/UuEf6GHRAl6moZvECufemxqgeByKs3o4ys6SNU+HynzppPTKZ5nNwx4EqcJXtAbhfPuMwHUQ==",
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-6.7.2.tgz",
+      "integrity": "sha512-xfYOwhHjOSOIqkk8A0h8zcaio/WyzrAWpMTu9hzV3Z5PI4tOG0Pq6a9Lh/mHr1r3bydif8R21qGvKU1Re9CpUg==",
       "dev": true,
       "requires": {
-        "bluebird-lst": "1.0.5",
-        "builder-util": "3.0.13",
-        "debug": "3.1.0",
-        "fs-extra-p": "4.4.4",
-        "iconv-lite": "0.4.19",
-        "js-yaml": "3.10.0",
-        "parse-color": "1.0.0"
+        "app-builder-lib": "~20.44.4",
+        "bluebird-lst": "^1.0.9",
+        "builder-util": "~10.1.2",
+        "fs-extra-p": "^8.0.2",
+        "iconv-lite": "^0.4.24",
+        "js-yaml": "^3.13.1",
+        "parse-color": "^1.0.0",
+        "sanitize-filename": "^1.6.1"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-          "dev": true
-        },
-        "bluebird-lst": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.5.tgz",
-          "integrity": "sha512-Ey0bDNys5qpYPhZ/oQ9vOEvD0TYQDTILMXWP2iGfvMg7rSDde+oV4aQQgqRH+CvBFNz2BSDQnPGMUl6LKBUUQA==",
-          "dev": true,
-          "requires": {
-            "bluebird": "3.5.1"
-          }
-        },
-        "color-convert": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.1"
-          }
-        },
-        "fs-extra-p": {
-          "version": "4.4.4",
-          "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.4.4.tgz",
-          "integrity": "sha512-zHsMNJWhXD184QfHKEIFSQSgAFNV7v9J+Nt2XpaLZp2nTz6WxZNV+R4G2uYeGeLTMaKvUZiqGKrH/4iFCupcUA==",
-          "dev": true,
-          "requires": {
-            "bluebird-lst": "1.0.5",
-            "fs-extra": "4.0.2"
-          }
-        },
         "iconv-lite": {
-          "version": "0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "requires": {
-            "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-            "esprima": "4.0.0"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "parse-color": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
-          "integrity": "sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=",
-          "dev": true,
-          "requires": {
-            "color-convert": "0.5.3"
-          }
-        },
-        "universalify": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-          "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-          "dev": true
         }
       }
     },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
+    },
     "dotenv": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
       "dev": true
     },
     "dotenv-expand": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.0.1.tgz",
-      "integrity": "sha1-aP3cFWGBTgoQlkERBX/xOM7X16g=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.2.0.tgz",
+      "integrity": "sha1-3vHxyl1gWdJKdm5YeULCEQbOEnU=",
+      "dev": true
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "ejs": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.1.tgz",
+      "integrity": "sha512-kS/gEPzZs3Y1rRsbGX4UOSjtP/CeJP0CxSNZHYxGfVM/VgLcv0ZqM7C45YyTj2DI2g7+P9Dd24C+IMIg6D0nYQ==",
       "dev": true
     },
     "electron-builder": {
-      "version": "19.40.0",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-19.40.0.tgz",
-      "integrity": "sha512-mXYdqSSuvN/jPFIziFzPhv3TSKHLKPRLXn8IPQ1hWV7I8cCKI31oTA6Y1orTJUBJuRqWBqPQlrhN8vRZ/DlbTA==",
+      "version": "20.44.4",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-20.44.4.tgz",
+      "integrity": "sha512-H8zzP01albkKh2Ec1zc0A7RGriUkHb5M99NJskaYtgKtGATTAGH+r9OIWVk5Hk9c1dLMVudbqEeaSlygMF2asw==",
       "dev": true,
       "requires": {
-        "7zip-bin": "2.2.7",
-        "app-package-builder": "1.3.1",
-        "asar-integrity": "0.2.3",
-        "async-exit-hook": "2.0.1",
-        "bluebird-lst": "1.0.5",
-        "builder-util": "3.0.13",
-        "builder-util-runtime": "2.4.0",
-        "chalk": "2.1.0",
-        "chromium-pickle-js": "0.2.0",
-        "cuint": "0.2.2",
-        "debug": "3.1.0",
-        "dmg-builder": "2.1.3",
-        "ejs": "2.5.7",
-        "electron-download-tf": "4.3.4",
-        "electron-osx-sign": "0.4.7",
-        "electron-publish": "19.40.0",
-        "fs-extra-p": "4.4.4",
-        "hosted-git-info": "2.5.0",
-        "is-ci": "1.0.10",
-        "isbinaryfile": "3.0.2",
-        "js-yaml": "3.10.0",
-        "lazy-val": "1.0.2",
-        "minimatch": "3.0.4",
-        "normalize-package-data": "2.4.0",
-        "plist": "2.1.0",
-        "read-config-file": "1.2.0",
-        "sanitize-filename": "1.6.1",
-        "semver": "5.4.1",
-        "temp-file": "2.0.3",
-        "update-notifier": "2.3.0",
-        "yargs": "10.0.3"
+        "app-builder-lib": "20.44.4",
+        "bluebird-lst": "^1.0.9",
+        "builder-util": "10.1.2",
+        "builder-util-runtime": "8.2.5",
+        "chalk": "^2.4.2",
+        "dmg-builder": "6.7.2",
+        "fs-extra-p": "^8.0.2",
+        "is-ci": "^2.0.0",
+        "lazy-val": "^1.0.4",
+        "read-config-file": "3.2.2",
+        "sanitize-filename": "^1.6.1",
+        "update-notifier": "^3.0.0",
+        "yargs": "^13.2.4"
       },
       "dependencies": {
-        "7zip-bin": {
-          "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-2.2.7.tgz",
-          "integrity": "sha512-+rr4OgeTNrLuJAf09o3USdttEYiXvZshWMkhD6wR9v1ieXH0JM1Q2yT41/cJuJcqiPpSXlM/g3aR+Y5MWQdr0Q==",
-          "dev": true,
-          "requires": {
-            "7zip-bin-mac": "1.0.1"
-          }
-        },
-        "7zip-bin-mac": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/7zip-bin-mac/-/7zip-bin-mac-1.0.1.tgz",
-          "integrity": "sha1-Pmh3i78JJq3GgVlCcHRQXUdVXAI=",
-          "dev": true,
-          "optional": true
-        },
-        "7zip-bin-win": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/7zip-bin-win/-/7zip-bin-win-2.1.1.tgz",
-          "integrity": "sha512-6VGEW7PXGroTsoI2QW3b0ea95HJmbVBHvfANKLLMzSzFA1zKqVX5ybNuhmeGpf6vA0x8FJTt6twpprDANsY5WQ=="
-        },
-        "ansi-align": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-          "dev": true,
-          "requires": {
-            "string-width": "2.1.1"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-              "dev": true,
-              "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
-              }
-            }
-          }
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz"
+            "color-convert": "^1.9.0"
           }
-        },
-        "asar-integrity": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asar-integrity/-/asar-integrity-0.2.3.tgz",
-          "integrity": "sha512-c+oMuxlpKRDv9Kv6WdjbnkySfSYATAmW+cvy8NIdMg9twY9RMvSdvOoPssroWlTpSra1qX9vLew2ROpV4jQm7w==",
-          "dev": true,
-          "requires": {
-            "bluebird-lst": "1.0.5",
-            "fs-extra-p": "4.4.4"
-          }
-        },
-        "base64-js": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
-          "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
-          "dev": true
-        },
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-          "dev": true
-        },
-        "bluebird-lst": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.5.tgz",
-          "integrity": "sha512-Ey0bDNys5qpYPhZ/oQ9vOEvD0TYQDTILMXWP2iGfvMg7rSDde+oV4aQQgqRH+CvBFNz2BSDQnPGMUl6LKBUUQA==",
-          "dev": true,
-          "requires": {
-            "bluebird": "3.5.1"
-          }
-        },
-        "boxen": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.2.tgz",
-          "integrity": "sha1-Px1AMsMP/qnUsCwyLq8up0HcvOU=",
-          "dev": true,
-          "requires": {
-            "ansi-align": "2.0.0",
-            "camelcase": "4.1.0",
-            "chalk": "2.1.0",
-            "cli-boxes": "1.0.0",
-            "string-width": "2.1.1",
-            "term-size": "1.2.0",
-            "widest-line": "1.0.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-              "dev": true,
-              "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
-              }
-            }
-          }
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "supports-color": "4.5.0"
-          }
-        },
-        "chromium-pickle-js": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
-          "integrity": "sha1-BKEGZywYsIWrd02YPfo+oTjyIgU=",
-          "dev": true
-        },
-        "ci-info": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
-          "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
-          "dev": true
-        },
-        "cli-boxes": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-          "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            }
-          }
-        },
-        "compare-version": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
-          "integrity": "sha1-AWLsLZNR9d3VmpICy6k1NmpyUIA=",
-          "dev": true
-        },
-        "configstore": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-          "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
-          "dev": true,
-          "requires": {
-            "dot-prop": "4.2.0",
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "make-dir": "1.1.0",
-            "unique-string": "1.0.0",
-            "write-file-atomic": "2.3.0",
-            "xdg-basedir": "3.0.0"
-          }
-        },
-        "create-error-class": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-          "dev": true,
-          "requires": {
-            "capture-stack-trace": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
-          }
-        },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
-          }
-        },
-        "crypto-random-string": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-          "dev": true
-        },
-        "cuint": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
-          "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "dot-prop": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-          "dev": true,
-          "requires": {
-            "is-obj": "1.0.1"
-          }
-        },
-        "duplexer3": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-          "dev": true
-        },
-        "ejs": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
-          "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=",
-          "dev": true
-        },
-        "electron-download-tf": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/electron-download-tf/-/electron-download-tf-4.3.4.tgz",
-          "integrity": "sha512-SQYDGMLpTgty1bx3NycuDb7dNPzktVSdK2sqPZjyRocauq/uN/V4S2lcpFVLupaHhKlD8zozm9fTpm5UdohvTg==",
-          "dev": true,
-          "requires": {
-            "debug": "3.1.0",
-            "env-paths": "1.0.0",
-            "fs-extra": "4.0.2",
-            "minimist": "1.2.0",
-            "nugget": "2.0.1",
-            "path-exists": "3.0.0",
-            "rc": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-            "semver": "5.4.1",
-            "sumchecker": "2.0.2"
-          }
-        },
-        "electron-osx-sign": {
-          "version": "0.4.7",
-          "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.7.tgz",
-          "integrity": "sha1-HXVkeoJ0jqzUi+pwYW7IP/rePuU=",
-          "dev": true,
-          "requires": {
-            "bluebird": "3.5.1",
-            "compare-version": "0.1.2",
-            "debug": "2.6.9",
-            "isbinaryfile": "3.0.2",
-            "minimist": "1.2.0",
-            "plist": "2.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
-        "electron-publish": {
-          "version": "19.40.0",
-          "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-19.40.0.tgz",
-          "integrity": "sha512-8SZOp+V3o65IYfKjOgkqis16uL3S6gQLK08MYs9ceGelQ5IEvC69lJslk0hCTAxwfczH6eL7QlGS3A/zAyWsbQ==",
-          "dev": true,
-          "requires": {
-            "bluebird-lst": "1.0.5",
-            "builder-util": "3.0.13",
-            "builder-util-runtime": "2.4.0",
-            "chalk": "2.1.0",
-            "fs-extra-p": "4.4.4",
-            "mime": "2.0.3"
-          }
-        },
-        "env-paths": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
-          "integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=",
-          "dev": true
-        },
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-          "dev": true
-        },
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "strip-eof": "1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.1"
-          }
-        },
-        "fs-extra-p": {
-          "version": "4.4.4",
-          "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.4.4.tgz",
-          "integrity": "sha512-zHsMNJWhXD184QfHKEIFSQSgAFNV7v9J+Nt2XpaLZp2nTz6WxZNV+R4G2uYeGeLTMaKvUZiqGKrH/4iFCupcUA==",
-          "dev": true,
-          "requires": {
-            "bluebird-lst": "1.0.5",
-            "fs-extra": "4.0.2"
-          }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
-        "got": {
-          "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-          "dev": true,
-          "requires": {
-            "create-error-class": "3.0.2",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-redirect": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "lowercase-keys": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-            "timed-out": "4.0.1",
-            "unzip-response": "2.0.1",
-            "url-parse-lax": "1.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "hosted-git-info": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-          "dev": true
-        },
-        "import-lazy": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-          "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-          "dev": true
-        },
-        "is-ci": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
-          "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
-          "dev": true,
-          "requires": {
-            "ci-info": "1.1.1"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "is-npm": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-          "dev": true
-        },
-        "is-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-          "dev": true
-        },
-        "is-retry-allowed": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-          "dev": true
-        },
-        "isbinaryfile": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz",
-          "integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE=",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-          "dev": true,
-          "requires": {
-            "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-            "esprima": "4.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-          }
-        },
-        "latest-version": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-          "dev": true,
-          "requires": {
-            "package-json": "4.0.1"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
-        },
-        "make-dir": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-          "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
-          "dev": true,
-          "requires": {
-            "pify": "3.0.0"
-          }
-        },
-        "mem": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz"
-          }
-        },
-        "mime": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.0.3.tgz",
-          "integrity": "sha512-TrpAd/vX3xaLPDgVRm6JkZwLR0KHfukMdU2wTEbqMDdCnY6Yo3mE+mjs9YE6oMNw2QRfXVeBEYpmpO94BIqiug==",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-          }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-          "dev": true,
-          "requires": {
-            "path-key": "2.0.1"
-          }
-        },
-        "nugget": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
-          "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "minimist": "1.2.0",
-            "pretty-bytes": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
-            "progress-stream": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
-            "request": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
-            "single-line-log": "1.1.2",
-            "throttleit": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
-          "requires": {
-            "execa": "0.7.0",
-            "lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-            "mem": "1.1.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-          "dev": true
-        },
-        "p-limit": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-          "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-          "dev": true
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "1.1.0"
-          }
-        },
-        "package-json": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-          "dev": true,
-          "requires": {
-            "got": "6.7.1",
-            "registry-auth-token": "3.3.1",
-            "registry-url": "3.1.0",
-            "semver": "5.4.1"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-          "dev": true
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        },
-        "plist": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
-          "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
-          "dev": true,
-          "requires": {
-            "base64-js": "1.2.0",
-            "xmlbuilder": "8.2.2",
-            "xmldom": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz"
-          }
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-          "dev": true
-        },
-        "registry-auth-token": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
-          "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
-          "dev": true,
-          "requires": {
-            "rc": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
-          }
-        },
-        "registry-url": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-          "dev": true,
-          "requires": {
-            "rc": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz"
-          }
-        },
-        "sanitize-filename": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
-          "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
-          "dev": true,
-          "requires": {
-            "truncate-utf8-bytes": "1.0.2"
-          }
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true
-        },
-        "semver-diff": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-          "dev": true,
-          "requires": {
-            "semver": "5.4.1"
-          }
-        },
-        "single-line-log": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
-          "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
-          "dev": true,
-          "requires": {
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "strip-eof": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-          "dev": true
-        },
-        "sumchecker": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-2.0.2.tgz",
-          "integrity": "sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
-          }
-        },
-        "term-size": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-          "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-          "dev": true,
-          "requires": {
-            "execa": "0.7.0"
-          }
-        },
-        "timed-out": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-          "dev": true
-        },
-        "truncate-utf8-bytes": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-          "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
-          "dev": true,
-          "requires": {
-            "utf8-byte-length": "1.0.4"
-          }
-        },
-        "unique-string": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-          "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-          "dev": true,
-          "requires": {
-            "crypto-random-string": "1.0.0"
-          }
-        },
-        "universalify": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-          "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-          "dev": true
-        },
-        "unzip-response": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-          "dev": true
-        },
-        "update-notifier": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-          "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
-          "dev": true,
-          "requires": {
-            "boxen": "1.2.2",
-            "chalk": "2.1.0",
-            "configstore": "3.1.1",
-            "import-lazy": "2.1.0",
-            "is-installed-globally": "0.1.0",
-            "is-npm": "1.0.0",
-            "latest-version": "3.1.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "3.0.0"
-          }
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-          "dev": true,
-          "requires": {
-            "prepend-http": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
-          }
-        },
-        "utf8-byte-length": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-          "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
-          "dev": true
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-          "dev": true
-        },
-        "widest-line": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
-          "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
-          "dev": true,
-          "requires": {
-            "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-          }
-        },
-        "write-file-atomic": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-          "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-          }
-        },
-        "xdg-basedir": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-          "dev": true
-        },
-        "xmlbuilder": {
-          "version": "8.2.2",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
-          "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
-          "dev": true
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "10.0.3",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-          "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
-          "dev": true,
-          "requires": {
-            "cliui": "3.2.0",
-            "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "find-up": "2.1.0",
-            "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-            "os-locale": "2.1.0",
-            "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "yargs-parser": "8.0.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-              "dev": true,
-              "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
-              }
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
-          "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -6180,15 +5256,15 @@
       "integrity": "sha1-v5MsdG8vh//MCdHdRy8v9rkYeEU=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "env-paths": "1.0.0",
-        "fs-extra": "2.1.2",
-        "minimist": "1.2.0",
-        "nugget": "2.0.1",
-        "path-exists": "3.0.0",
-        "rc": "1.2.2",
-        "semver": "5.4.1",
-        "sumchecker": "2.0.2"
+        "debug": "^2.2.0",
+        "env-paths": "^1.0.0",
+        "fs-extra": "^2.0.0",
+        "minimist": "^1.2.0",
+        "nugget": "^2.0.0",
+        "path-exists": "^3.0.0",
+        "rc": "^1.1.2",
+        "semver": "^5.3.0",
+        "sumchecker": "^2.0.1"
       },
       "dependencies": {
         "ajv": {
@@ -6197,10 +5273,10 @@
           "integrity": "sha1-Pa+ai2ciEpn9ro2C0RftjmyAJEs=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "0.3.1",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "json-schema-traverse": "^0.3.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ansi-regex": {
@@ -6252,7 +5328,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "boom": {
@@ -6261,7 +5337,7 @@
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         },
         "builtin-modules": {
@@ -6282,8 +5358,8 @@
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
           }
         },
         "caseless": {
@@ -6310,7 +5386,7 @@
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "core-util-is": {
@@ -6325,7 +5401,7 @@
           "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
           "dev": true,
           "requires": {
-            "boom": "5.2.0"
+            "boom": "5.x.x"
           },
           "dependencies": {
             "boom": {
@@ -6334,7 +5410,7 @@
               "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
               "dev": true,
               "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.x.x"
               }
             }
           }
@@ -6345,7 +5421,7 @@
           "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
           "dev": true,
           "requires": {
-            "array-find-index": "1.0.2"
+            "array-find-index": "^1.0.1"
           }
         },
         "dashdash": {
@@ -6354,7 +5430,7 @@
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "debug": {
@@ -6391,7 +5467,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "env-paths": {
@@ -6406,7 +5482,7 @@
           "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
           "dev": true,
           "requires": {
-            "is-arrayish": "0.2.1"
+            "is-arrayish": "^0.2.1"
           }
         },
         "extend": {
@@ -6427,8 +5503,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           },
           "dependencies": {
             "path-exists": {
@@ -6437,7 +5513,7 @@
               "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
               "dev": true,
               "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
               }
             }
           }
@@ -6454,9 +5530,9 @@
           "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs-extra": {
@@ -6465,8 +5541,8 @@
           "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0"
           }
         },
         "get-stdin": {
@@ -6481,7 +5557,7 @@
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -6502,8 +5578,8 @@
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "dev": true,
           "requires": {
-            "ajv": "5.2.4",
-            "har-schema": "2.0.0"
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
           }
         },
         "hawk": {
@@ -6512,10 +5588,10 @@
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
           "dev": true,
           "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.0.2"
+            "boom": "4.x.x",
+            "cryptiles": "3.x.x",
+            "hoek": "4.x.x",
+            "sntp": "2.x.x"
           }
         },
         "hoek": {
@@ -6536,9 +5612,9 @@
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "indent-string": {
@@ -6547,7 +5623,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "inherits": {
@@ -6574,7 +5650,7 @@
           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true,
           "requires": {
-            "builtin-modules": "1.1.1"
+            "builtin-modules": "^1.0.0"
           }
         },
         "is-finite": {
@@ -6583,7 +5659,7 @@
           "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -6592,7 +5668,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -6644,7 +5720,7 @@
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -6659,7 +5735,7 @@
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.6"
           }
         },
         "jsonify": {
@@ -6686,11 +5762,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "loud-rejection": {
@@ -6699,8 +5775,8 @@
           "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
           "dev": true,
           "requires": {
-            "currently-unhandled": "0.4.1",
-            "signal-exit": "3.0.2"
+            "currently-unhandled": "^0.4.1",
+            "signal-exit": "^3.0.0"
           }
         },
         "map-obj": {
@@ -6715,16 +5791,16 @@
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
           }
         },
         "mime-db": {
@@ -6739,7 +5815,7 @@
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "dev": true,
           "requires": {
-            "mime-db": "1.30.0"
+            "mime-db": "~1.30.0"
           }
         },
         "ms": {
@@ -6754,10 +5830,10 @@
           "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "nugget": {
@@ -6766,12 +5842,12 @@
           "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "minimist": "1.2.0",
-            "pretty-bytes": "1.0.4",
-            "progress-stream": "1.2.0",
-            "request": "2.83.0",
-            "single-line-log": "1.1.2",
+            "debug": "^2.1.3",
+            "minimist": "^1.1.0",
+            "pretty-bytes": "^1.0.2",
+            "progress-stream": "^1.1.0",
+            "request": "^2.45.0",
+            "single-line-log": "^1.1.2",
             "throttleit": "0.0.2"
           }
         },
@@ -6799,7 +5875,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -6814,9 +5890,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "performance-now": {
@@ -6843,7 +5919,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "pretty-bytes": {
@@ -6852,8 +5928,8 @@
           "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
+            "get-stdin": "^4.0.1",
+            "meow": "^3.1.0"
           }
         },
         "progress-stream": {
@@ -6862,8 +5938,8 @@
           "integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
           "dev": true,
           "requires": {
-            "speedometer": "0.1.4",
-            "through2": "0.2.3"
+            "speedometer": "~0.1.2",
+            "through2": "~0.2.3"
           }
         },
         "punycode": {
@@ -6884,10 +5960,10 @@
           "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
           "dev": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           }
         },
         "read-pkg": {
@@ -6896,9 +5972,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -6907,8 +5983,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "readable-stream": {
@@ -6917,10 +5993,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "redent": {
@@ -6929,8 +6005,8 @@
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "dev": true,
           "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
           }
         },
         "repeating": {
@@ -6939,7 +6015,7 @@
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "request": {
@@ -6948,28 +6024,28 @@
           "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           }
         },
         "safe-buffer": {
@@ -6996,7 +6072,7 @@
           "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.1"
           }
         },
         "sntp": {
@@ -7005,7 +6081,7 @@
           "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         },
         "spdx-correct": {
@@ -7014,7 +6090,7 @@
           "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
           "dev": true,
           "requires": {
-            "spdx-license-ids": "1.2.2"
+            "spdx-license-ids": "^1.0.2"
           }
         },
         "spdx-expression-parse": {
@@ -7041,21 +6117,15 @@
           "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
           "dev": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
           }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
         },
         "string-width": {
           "version": "1.0.2",
@@ -7063,10 +6133,16 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
         },
         "stringstream": {
           "version": "0.0.5",
@@ -7080,7 +6156,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -7089,7 +6165,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-indent": {
@@ -7098,7 +6174,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1"
+            "get-stdin": "^4.0.1"
           }
         },
         "strip-json-comments": {
@@ -7113,7 +6189,7 @@
           "integrity": "sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9"
+            "debug": "^2.2.0"
           }
         },
         "throttleit": {
@@ -7128,8 +6204,8 @@
           "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.1.14",
-            "xtend": "2.1.2"
+            "readable-stream": "~1.1.9",
+            "xtend": "~2.1.1"
           }
         },
         "tough-cookie": {
@@ -7138,7 +6214,7 @@
           "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
           "dev": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "trim-newlines": {
@@ -7153,7 +6229,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -7169,8 +6245,8 @@
           "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "dev": true,
           "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
+            "spdx-correct": "~1.0.0",
+            "spdx-expression-parse": "~1.0.0"
           }
         },
         "verror": {
@@ -7179,9 +6255,9 @@
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
+            "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
+            "extsprintf": "^1.2.0"
           }
         },
         "xtend": {
@@ -7190,74 +6266,25 @@
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "dev": true,
           "requires": {
-            "object-keys": "0.4.0"
+            "object-keys": "~0.4.0"
           }
         }
       }
     },
-    "electron-packager": {
-      "version": "8.7.2",
-      "resolved": "https://registry.npmjs.org/electron-packager/-/electron-packager-8.7.2.tgz",
-      "integrity": "sha1-RX078kvJYHwGrUsettqkrMrcIQg=",
+    "electron-osx-sign": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.11.tgz",
+      "integrity": "sha512-VVd40nrnVqymvFrY9ZkOYgHJOvexHHYTR3di/SN+mjJ0OWhR1I8BRVj3U+Yamw6hnkZZNKZp52rqL5EFAAPFkQ==",
       "dev": true,
       "requires": {
-        "asar": "0.13.0",
-        "debug": "2.6.9",
-        "electron-download": "4.1.0",
-        "electron-osx-sign": "0.4.7",
-        "extract-zip": "1.6.5",
-        "fs-extra": "3.0.1",
-        "get-package-info": "1.0.0",
-        "minimist": "1.2.0",
-        "plist": "2.1.0",
-        "rcedit": "0.9.0",
-        "resolve": "1.4.0",
-        "run-series": "1.1.4",
-        "sanitize-filename": "1.6.1",
-        "semver": "5.4.1"
+        "bluebird": "^3.5.0",
+        "compare-version": "^0.1.2",
+        "debug": "^2.6.8",
+        "isbinaryfile": "^3.0.2",
+        "minimist": "^1.2.0",
+        "plist": "^3.0.1"
       },
       "dependencies": {
-        "base64-js": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
-          "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
-          "dev": true
-        },
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-          "dev": true
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-          "dev": true
-        },
-        "compare-version": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
-          "integrity": "sha1-AWLsLZNR9d3VmpICy6k1NmpyUIA=",
-          "dev": true
-        },
-        "concat-stream": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
-          }
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -7267,196 +6294,13 @@
             "ms": "2.0.0"
           }
         },
-        "electron-osx-sign": {
-          "version": "0.4.7",
-          "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.7.tgz",
-          "integrity": "sha1-HXVkeoJ0jqzUi+pwYW7IP/rePuU=",
-          "dev": true,
-          "requires": {
-            "bluebird": "3.5.1",
-            "compare-version": "0.1.2",
-            "debug": "2.6.9",
-            "isbinaryfile": "3.0.2",
-            "minimist": "1.2.0",
-            "plist": "2.1.0"
-          }
-        },
-        "error-ex": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-          "dev": true,
-          "requires": {
-            "is-arrayish": "0.2.1"
-          }
-        },
-        "extract-zip": {
-          "version": "1.6.5",
-          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
-          "integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
-          "dev": true,
-          "requires": {
-            "concat-stream": "1.6.0",
-            "debug": "2.2.0",
-            "mkdirp": "0.5.0",
-            "yauzl": "2.4.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-              "dev": true,
-              "requires": {
-                "ms": "0.7.1"
-              }
-            },
-            "ms": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-              "dev": true
-            }
-          }
-        },
-        "fd-slicer": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-          "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-          "dev": true,
-          "requires": {
-            "pend": "1.2.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-          "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "3.0.1",
-            "universalify": "0.1.1"
-          }
-        },
-        "get-package-info": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/get-package-info/-/get-package-info-1.0.0.tgz",
-          "integrity": "sha1-ZDJ5ZWPigRPNlHTbvQAFKYWkmZw=",
-          "dev": true,
-          "requires": {
-            "bluebird": "3.5.1",
-            "debug": "2.6.9",
-            "lodash.get": "4.4.2",
-            "read-pkg-up": "2.0.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "hosted-git-info": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-          "dev": true
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-          "dev": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-          "dev": true,
-          "requires": {
-            "builtin-modules": "1.1.1"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
         "isbinaryfile": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz",
-          "integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE=",
-          "dev": true
-        },
-        "jsonfile": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
+          "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
-          }
-        },
-        "lodash.get": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-          "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
-            }
+            "buffer-alloc": "^1.2.0"
           }
         },
         "ms": {
@@ -7464,75 +6308,139 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+        }
+      }
+    },
+    "electron-packager": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/electron-packager/-/electron-packager-12.2.0.tgz",
+      "integrity": "sha512-T5W/FIK4VXhYIOWxkehmz6zXt2S/sA9JZ3AL+/jeKCicQY6QVQ0K8B7W801L+GPTwbgTPycHjO+iqEf1BhZ+Iw==",
+      "dev": true,
+      "requires": {
+        "asar": "^0.14.0",
+        "debug": "^3.0.0",
+        "electron-download": "^4.1.1",
+        "electron-osx-sign": "^0.4.1",
+        "extract-zip": "^1.0.3",
+        "fs-extra": "^5.0.0",
+        "galactus": "^0.2.1",
+        "get-package-info": "^1.0.0",
+        "nodeify": "^1.0.1",
+        "parse-author": "^2.0.0",
+        "pify": "^3.0.0",
+        "plist": "^2.0.0",
+        "rcedit": "^1.0.0",
+        "resolve": "^1.1.6",
+        "sanitize-filename": "^1.6.0",
+        "semver": "^5.3.0",
+        "yargs-parser": "^10.0.0"
+      },
+      "dependencies": {
+        "asar": {
+          "version": "0.14.6",
+          "resolved": "https://registry.npmjs.org/asar/-/asar-0.14.6.tgz",
+          "integrity": "sha512-ZqybKcdO5At6y3ge2RHxVImc6Eltb2t3sxT7lk4T4zjZBSFUuIGCIZY6f41dCjlvJSizN5QPRr8YTgMhpgBjLg==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1"
+            "chromium-pickle-js": "^0.2.0",
+            "commander": "^2.9.0",
+            "cuint": "^0.2.1",
+            "glob": "^6.0.4",
+            "minimatch": "^3.0.3",
+            "mkdirp": "^0.5.0",
+            "mksnapshot": "^0.3.4",
+            "tmp": "0.0.28"
           }
         },
-        "p-limit": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-          "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-          "dev": true
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "1.1.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-          "dev": true
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "2.3.0"
-          }
-        },
-        "pend": {
+        "base64-js": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-          "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+          "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
           "dev": true
         },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "electron-download": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-4.1.1.tgz",
+          "integrity": "sha512-FjEWG9Jb/ppK/2zToP+U5dds114fM1ZOJqMAR4aXXL5CvyPE9fiqBK/9YcwC9poIFQTEJk/EM/zyRwziziRZrg==",
+          "dev": true,
+          "requires": {
+            "debug": "^3.0.0",
+            "env-paths": "^1.0.0",
+            "fs-extra": "^4.0.1",
+            "minimist": "^1.2.0",
+            "nugget": "^2.0.1",
+            "path-exists": "^3.0.0",
+            "rc": "^1.2.1",
+            "semver": "^5.4.1",
+            "sumchecker": "^2.0.2"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+              "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+              }
+            },
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
+          }
+        },
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
         },
         "plist": {
           "version": "2.1.0",
@@ -7542,170 +6450,7 @@
           "requires": {
             "base64-js": "1.2.0",
             "xmlbuilder": "8.2.2",
-            "xmldom": "0.1.27"
-          }
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "rcedit": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/rcedit/-/rcedit-0.9.0.tgz",
-          "integrity": "sha1-ORDfVzRTmeKwMl9KUZAH+J5V7xw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "resolve": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-          "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-          "dev": true,
-          "requires": {
-            "path-parse": "1.0.5"
-          }
-        },
-        "run-series": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz",
-          "integrity": "sha1-iac93F51ye+KtjIMChYA1qQRebk=",
-          "dev": true
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
-        },
-        "sanitize-filename": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
-          "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
-          "dev": true,
-          "requires": {
-            "truncate-utf8-bytes": "1.0.2"
-          }
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true
-        },
-        "spdx-correct": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-          "dev": true,
-          "requires": {
-            "spdx-license-ids": "1.2.2"
-          }
-        },
-        "spdx-expression-parse": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-          "dev": true
-        },
-        "spdx-license-ids": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        },
-        "truncate-utf8-bytes": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-          "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
-          "dev": true,
-          "requires": {
-            "utf8-byte-length": "1.0.4"
-          }
-        },
-        "typedarray": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-          "dev": true
-        },
-        "universalify": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-          "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-          "dev": true
-        },
-        "utf8-byte-length": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-          "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
-          "dev": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-          "dev": true,
-          "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
+            "xmldom": "0.1.x"
           }
         },
         "xmlbuilder": {
@@ -7714,19 +6459,13 @@
           "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
           "dev": true
         },
-        "xmldom": {
-          "version": "0.1.27",
-          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-          "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
-          "dev": true
-        },
-        "yauzl": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-          "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "dev": true,
           "requires": {
-            "fd-slicer": "1.0.1"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -7735,2965 +6474,173 @@
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/electron-prebuilt/-/electron-prebuilt-1.4.13.tgz",
       "integrity": "sha1-Cg5Ne/iVokIGHM+rKTlNzaHaM9I=",
-      "dev": true,
       "requires": {
-        "electron-download": "3.3.0",
-        "extract-zip": "1.6.5"
+        "electron-download": "^3.0.1",
+        "extract-zip": "^1.0.3"
       },
       "dependencies": {
-        "ajv": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
-          "integrity": "sha1-Pa+ai2ciEpn9ro2C0RftjmyAJEs=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "0.3.1",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "array-find-index": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-          "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-          "dev": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-          "dev": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-          "dev": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "boom": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        },
-        "camelcase-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-          "dev": true,
-          "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
-          }
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-          "dev": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-          "dev": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
-        },
-        "concat-stream": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-              "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-              "dev": true,
-              "requires": {
-                "safe-buffer": "5.1.1"
-              }
-            }
-          }
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-          "dev": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-              "dev": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "currently-unhandled": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-          "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-          "dev": true,
-          "requires": {
-            "array-find-index": "1.0.2"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
-          }
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-          "dev": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
           }
         },
         "electron-download": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz",
           "integrity": "sha1-LP1U1pZsAZxNSa1l++Zcyc3vaMg=",
-          "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "fs-extra": "0.30.0",
-            "home-path": "1.0.5",
-            "minimist": "1.2.0",
-            "nugget": "2.0.1",
-            "path-exists": "2.1.0",
-            "rc": "1.2.2",
-            "semver": "5.4.1",
-            "sumchecker": "1.3.1"
-          }
-        },
-        "error-ex": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-          "dev": true,
-          "requires": {
-            "is-arrayish": "0.2.1"
-          }
-        },
-        "es6-promise": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-          "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
-          "dev": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-          "dev": true
-        },
-        "extract-zip": {
-          "version": "1.6.5",
-          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
-          "integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
-          "dev": true,
-          "requires": {
-            "concat-stream": "1.6.0",
-            "debug": "2.2.0",
-            "mkdirp": "0.5.0",
-            "yauzl": "2.4.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-              "dev": true,
-              "requires": {
-                "ms": "0.7.1"
-              }
-            },
-            "ms": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-              "dev": true
-            }
-          }
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-          "dev": true
-        },
-        "fd-slicer": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-          "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-          "dev": true,
-          "requires": {
-            "pend": "1.2.0"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "debug": "^2.2.0",
+            "fs-extra": "^0.30.0",
+            "home-path": "^1.0.1",
+            "minimist": "^1.2.0",
+            "nugget": "^2.0.0",
+            "path-exists": "^2.1.0",
+            "rc": "^1.1.2",
+            "semver": "^5.3.0",
+            "sumchecker": "^1.2.0"
           }
         },
         "fs-extra": {
           "version": "0.30.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-          "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-          "dev": true
-        },
-        "get-stdin": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-          "dev": true
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-          "dev": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-          "dev": true,
-          "requires": {
-            "ajv": "5.2.4",
-            "har-schema": "2.0.0"
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-          "dev": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.0.2"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-          "dev": true
-        },
-        "home-path": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz",
-          "integrity": "sha1-eIspgVsS1Tus9XVkhHbm+QQdEz8=",
-          "dev": true
-        },
-        "hosted-git-info": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "indent-string": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-          "dev": true,
-          "requires": {
-            "repeating": "2.0.1"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-          "dev": true
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-          "dev": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-          "dev": true,
-          "requires": {
-            "builtin-modules": "1.1.1"
-          }
-        },
-        "is-finite": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-          "dev": true
-        },
-        "is-utf8": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-          "dev": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-          "dev": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-          "dev": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "dev": true
         },
         "jsonfile": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-          "dev": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "klaw": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-          "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "loud-rejection": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-          "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-          "dev": true,
-          "requires": {
-            "currently-unhandled": "0.4.1",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        },
-        "meow": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-          "dev": true,
-          "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
-          }
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
-            }
+            "graceful-fs": "^4.1.6"
           }
         },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1"
-          }
-        },
-        "nugget": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
-          "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "minimist": "1.2.0",
-            "pretty-bytes": "1.0.4",
-            "progress-stream": "1.2.0",
-            "request": "2.83.0",
-            "single-line-log": "1.1.2",
-            "throttleit": "0.0.2"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "dev": true
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-          "dev": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pend": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-          "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-          "dev": true
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-          "dev": true
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "pretty-bytes": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
-          "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
-          }
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "progress-stream": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
-          "integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
-          "dev": true,
-          "requires": {
-            "speedometer": "0.1.4",
-            "through2": "0.2.3"
-          }
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-          "dev": true
-        },
-        "rc": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
-          "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
-          "dev": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "redent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-          "dev": true,
-          "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
-          }
-        },
-        "repeating": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.83.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true
-        },
-        "single-line-log": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
-          "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "sntp": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-          "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "spdx-correct": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-          "dev": true,
-          "requires": {
-            "spdx-license-ids": "1.2.2"
-          }
-        },
-        "spdx-expression-parse": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-          "dev": true
-        },
-        "spdx-license-ids": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-          "dev": true
-        },
-        "speedometer": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
-          "integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0=",
-          "dev": true
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-          "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-          "dev": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
-        "strip-indent": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
         },
         "sumchecker": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz",
           "integrity": "sha1-ebs7RFbdBPGOvbwNcDodHa7FEF0=",
-          "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "es6-promise": "4.1.1"
-          }
-        },
-        "throttleit": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-          "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
-          "dev": true
-        },
-        "through2": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
-          "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "1.1.14",
-            "xtend": "2.1.2"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-          "dev": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-          "dev": true
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-          "dev": true,
-          "optional": true
-        },
-        "typedarray": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-          "dev": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-          "dev": true,
-          "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
-          }
-        },
-        "verror": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "dev": true,
-          "requires": {
-            "object-keys": "0.4.0"
-          }
-        },
-        "yauzl": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-          "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-          "dev": true,
-          "requires": {
-            "fd-slicer": "1.0.1"
+            "debug": "^2.2.0",
+            "es6-promise": "^4.0.5"
           }
         }
       }
     },
-    "electron-release": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/electron-release/-/electron-release-2.2.0.tgz",
-      "integrity": "sha1-gvrUUxiwuL/H8pzRz4uR5m/nqyY=",
+    "electron-publish": {
+      "version": "20.44.4",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-20.44.4.tgz",
+      "integrity": "sha512-50NzsKOnNqOpGJzPl04vMyitdguUvp15FWKWtu4KISsHfgdLMWGgxHGZwfMphc/vf364zXvPHsYQza3MASgaEQ==",
       "dev": true,
       "requires": {
-        "bluebird": "2.11.0",
-        "chalk": "1.1.3",
-        "got": "4.2.0",
-        "load-json-file": "1.1.0",
-        "meow": "3.7.0",
-        "pretty-bytes": "2.0.1",
-        "publish-release": "1.3.3",
-        "single-line-log": "1.1.2",
-        "write-json-file": "1.2.0"
+        "bluebird-lst": "^1.0.9",
+        "builder-util": "~10.1.2",
+        "builder-util-runtime": "^8.2.5",
+        "chalk": "^2.4.2",
+        "fs-extra-p": "^8.0.2",
+        "lazy-val": "^1.0.4",
+        "mime": "^2.4.4"
       },
       "dependencies": {
-        "ajv": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
-          "integrity": "sha1-Pa+ai2ciEpn9ro2C0RftjmyAJEs=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "0.3.1",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
         "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "array-find-index": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-          "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-          "dev": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-          "dev": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        },
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-          "dev": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-          "dev": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "bl": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-          "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-              "dev": true
-            }
+            "color-convert": "^1.9.0"
           }
-        },
-        "bluebird": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
-          "dev": true
-        },
-        "boom": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        },
-        "camelcase-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-          "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-          "dev": true,
-          "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
-          }
-        },
-        "capture-stack-trace": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-          "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-          "dev": true
         },
         "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "cli-width": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
-          "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
-          "dev": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-          "dev": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        },
-        "create-error-class": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-2.0.1.tgz",
-          "integrity": "sha1-qHWe1cjSFKRh6B0Y5wqssz3WPJw=",
-          "dev": true,
-          "requires": {
-            "capture-stack-trace": "1.0.0",
-            "inherits": "2.0.3"
-          }
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-          "dev": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-              "dev": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "currently-unhandled": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-          "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-          "dev": true,
-          "requires": {
-            "array-find-index": "1.0.2"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
-        },
-        "duplexer2": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-          "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "1.1.14"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "1.1.14",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-              "dev": true
-            }
-          }
-        },
-        "duplexify": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
-          "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "1.4.0",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "stream-shift": "1.0.0"
-          }
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "editor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
-          "dev": true
-        },
-        "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0"
-          }
-        },
-        "error-ex": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-          "dev": true,
-          "requires": {
-            "is-arrayish": "0.2.1"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-          "dev": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-          "dev": true
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
-          },
-          "dependencies": {
-            "object-assign": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-              "dev": true
-            }
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          },
-          "dependencies": {
-            "pinkie": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-              "dev": true
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-              "dev": true,
-              "requires": {
-                "pinkie": "2.0.4"
-              }
-            }
-          }
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "get-stdin": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-          "dev": true
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "ghauth": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/ghauth/-/ghauth-2.0.1.tgz",
-          "integrity": "sha1-ebfWiwvPjn0IUqI7FHU539MUrPY=",
-          "dev": true,
-          "requires": {
-            "bl": "0.9.5",
-            "hyperquest": "1.2.0",
-            "mkdirp": "0.5.1",
-            "read": "1.0.7",
-            "xtend": "4.0.1"
-          }
-        },
-        "github-url-to-object": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/github-url-to-object/-/github-url-to-object-1.6.0.tgz",
-          "integrity": "sha1-iR73+7+rqP7XFRCs2xtOk0apcNw=",
-          "dev": true,
-          "requires": {
-            "is-url": "1.2.2"
-          }
-        },
-        "got": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-4.2.0.tgz",
-          "integrity": "sha1-r1n0YYNL+v1yLLoBrPTBSp3V2gY=",
-          "dev": true,
-          "requires": {
-            "create-error-class": "2.0.1",
-            "duplexify": "3.5.1",
-            "is-plain-obj": "1.1.0",
-            "is-redirect": "1.0.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.0",
-            "node-status-codes": "1.0.0",
-            "object-assign": "3.0.0",
-            "parse-json": "2.2.0",
-            "pinkie-promise": "1.0.0",
-            "prepend-http": "1.0.4",
-            "read-all-stream": "3.1.0",
-            "timed-out": "2.0.0",
-            "unzip-response": "1.0.2"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-          "dev": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-          "dev": true,
-          "requires": {
-            "ajv": "5.2.4",
-            "har-schema": "2.0.0"
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-          "dev": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.0.2"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-          "dev": true
-        },
-        "hosted-git-info": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "hyperquest": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-1.2.0.tgz",
-          "integrity": "sha1-OeH+9miI3Hzg3sbA3YFPb8iUStU=",
-          "dev": true,
-          "requires": {
-            "duplexer2": "0.0.2",
-            "through2": "0.6.5"
-          }
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-          "dev": true
-        },
-        "indent-string": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-          "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-          "dev": true,
-          "requires": {
-            "repeating": "2.0.1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "inquirer": {
-          "version": "0.8.5",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
-          "integrity": "sha1-29dAz2yjtzEpamPOb22WGFHzNt8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "1.1.1",
-            "chalk": "1.1.3",
-            "cli-width": "1.1.1",
-            "figures": "1.7.0",
-            "lodash": "3.10.1",
-            "readline2": "0.1.1",
-            "rx": "2.5.3",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-              "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
-              "dev": true
-            }
-          }
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-          "dev": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-          "dev": true,
-          "requires": {
-            "builtin-modules": "1.1.1"
-          }
-        },
-        "is-finite": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-plain-obj": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-          "dev": true
-        },
-        "is-redirect": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-          "dev": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-          "dev": true
-        },
-        "is-url": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
-          "integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY=",
-          "dev": true
-        },
-        "is-utf8": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-          "dev": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-          "dev": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-          "dev": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "dev": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-          "dev": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          },
-          "dependencies": {
-            "pinkie": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-              "dev": true
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-              "dev": true,
-              "requires": {
-                "pinkie": "2.0.4"
-              }
-            }
-          }
-        },
-        "loud-rejection": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-          "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-          "dev": true,
-          "requires": {
-            "currently-unhandled": "0.4.1",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "lowercase-keys": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-          "dev": true
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        },
-        "meow": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-          "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-          "dev": true,
-          "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
-          },
-          "dependencies": {
-            "object-assign": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-              "dev": true
-            }
-          }
-        },
-        "mime": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-          "dev": true
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
-            }
-          }
-        },
-        "mute-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-          "dev": true
-        },
-        "node-status-codes": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
-          "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
-          "dev": true
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-          "dev": true
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-          "dev": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          },
-          "dependencies": {
-            "pinkie": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-              "dev": true
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-              "dev": true,
-              "requires": {
-                "pinkie": "2.0.4"
-              }
-            }
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          },
-          "dependencies": {
-            "pinkie": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-              "dev": true
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-              "dev": true,
-              "requires": {
-                "pinkie": "2.0.4"
-              }
-            }
-          }
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-          "dev": true
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "pinkie": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
-          "integrity": "sha1-Wkfyi6EBXQIBvae/DzWOR77Ix+Q=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
-          "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
-          "dev": true,
-          "requires": {
-            "pinkie": "1.0.0"
-          }
-        },
-        "pkginfo": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
-          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
-          "dev": true
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-          "dev": true
-        },
-        "pretty-bytes": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-2.0.1.tgz",
-          "integrity": "sha1-FV7E0ANvQTkecEXW2+SWPVJdJk8=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0",
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "progress-stream": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
-          "integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
-          "dev": true,
-          "requires": {
-            "speedometer": "0.1.4",
-            "through2": "0.2.3"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "1.1.14",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-              "dev": true
-            },
-            "through2": {
-              "version": "0.2.3",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
-              "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
-              "dev": true,
-              "requires": {
-                "readable-stream": "1.1.14",
-                "xtend": "2.1.2"
-              }
-            },
-            "xtend": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-              "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-              "dev": true,
-              "requires": {
-                "object-keys": "0.4.0"
-              }
-            }
-          }
-        },
-        "publish-release": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/publish-release/-/publish-release-1.3.3.tgz",
-          "integrity": "sha1-bNEd+DXhTBOw4Io10/uZK5GL7Dw=",
-          "dev": true,
-          "requires": {
-            "async": "0.9.2",
-            "ghauth": "2.0.1",
-            "github-url-to-object": "1.6.0",
-            "inquirer": "0.8.5",
-            "lodash": "3.10.1",
-            "mime": "1.4.1",
-            "minimist": "1.2.0",
-            "pkginfo": "0.3.1",
-            "pretty-bytes": "1.0.4",
-            "progress-stream": "1.2.0",
-            "request": "2.83.0",
-            "single-line-log": "0.4.1",
-            "string-editor": "0.1.2"
-          },
-          "dependencies": {
-            "pretty-bytes": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
-              "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
-              "dev": true,
-              "requires": {
-                "get-stdin": "4.0.1",
-                "meow": "3.7.0"
-              }
-            },
-            "single-line-log": {
-              "version": "0.4.1",
-              "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz",
-              "integrity": "sha1-h6VWSfdJ14PsDc2AToFA2Yc8fO4=",
-              "dev": true
-            }
-          }
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-          "dev": true
-        },
-        "read": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-          "dev": true,
-          "requires": {
-            "mute-stream": "0.0.7"
-          }
-        },
-        "read-all-stream": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
-          "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1",
-            "readable-stream": "2.3.3"
-          },
-          "dependencies": {
-            "pinkie": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-              "dev": true
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-              "dev": true,
-              "requires": {
-                "pinkie": "2.0.4"
-              }
-            }
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "readline2": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
-          "integrity": "sha1-mUQ7pug7gw7zBRv9fcJBqCco1Wg=",
-          "dev": true,
-          "requires": {
-            "mute-stream": "0.0.4",
-            "strip-ansi": "2.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-              "integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0=",
-              "dev": true
-            },
-            "mute-stream": {
-              "version": "0.0.4",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
-              "integrity": "sha1-qSGZYKbV1dBGWXruUSUsZlX3F34=",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-              "integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "1.1.1"
-              }
-            }
-          }
-        },
-        "redent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-          "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-          "dev": true,
-          "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
-          }
-        },
-        "repeating": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-          "dev": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.83.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
-          }
-        },
-        "rx": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz",
-          "integrity": "sha1-Ia3H2A8CACr1Da6X/Z2/JIdV9WY=",
-          "dev": true
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true
-        },
-        "single-line-log": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
-          "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "slide": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-          "dev": true
-        },
-        "sntp": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-          "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "sort-keys": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-          "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-          "dev": true,
-          "requires": {
-            "is-plain-obj": "1.1.0"
-          }
-        },
-        "spdx-correct": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-          "dev": true,
-          "requires": {
-            "spdx-license-ids": "1.2.2"
-          }
-        },
-        "spdx-expression-parse": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-          "dev": true
-        },
-        "spdx-license-ids": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-          "dev": true
-        },
-        "speedometer": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
-          "integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0=",
-          "dev": true
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-          "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-          "dev": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "stream-shift": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-          "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "string-editor": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/string-editor/-/string-editor-0.1.2.tgz",
-          "integrity": "sha1-9f8bWsSu16xsL7jeI20VUbIPYdA=",
-          "dev": true,
-          "requires": {
-            "editor": "1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
-        "strip-indent": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-          "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-          "dev": true,
-          "requires": {
-            "get-stdin": "4.0.1"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "through": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-          "dev": true
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-              "dev": true
-            }
+            "has-flag": "^3.0.0"
           }
-        },
-        "timed-out": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
-          "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo=",
-          "dev": true
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-          "dev": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "trim-newlines": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-          "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-          "dev": true
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-          "dev": true,
-          "optional": true
-        },
-        "unzip-response": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-          "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
-          "dev": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-          "dev": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-          "dev": true,
-          "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
-          }
-        },
-        "verror": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        },
-        "write-file-atomic": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
-          }
-        },
-        "write-json-file": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-1.2.0.tgz",
-          "integrity": "sha1-LV3+lqvDyIkFfJOXGqQAXvtUgTQ=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "sort-keys": "1.1.2",
-            "write-file-atomic": "1.3.4"
-          },
-          "dependencies": {
-            "object-assign": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-              "dev": true
-            },
-            "pinkie": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-              "dev": true
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-              "dev": true,
-              "requires": {
-                "pinkie": "2.0.4"
-              }
-            }
-          }
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
         }
       }
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
-      }
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "dev": true
     },
     "end-of-stream": {
-      "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-      "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz"
-      },
-      "dependencies": {
-        "once": {
-          "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-          "dev": true,
-          "requires": {
-            "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-          }
-        }
+        "once": "^1.4.0"
       }
     },
     "entities": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+    },
+    "env-paths": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
+      "integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=",
+      "dev": true
     },
     "error-ex": {
-      "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true,
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
-        "is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+        "is-arrayish": "^0.2.1"
       }
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
     "escape-string-regexp": {
-      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
@@ -10703,8 +6650,8 @@
       "integrity": "sha1-fbBo4fVIf2hx5N7vNqOBwwPqwWE=",
       "dev": true,
       "requires": {
-        "doctrine": "1.5.0",
-        "jsx-ast-utils": "1.4.1"
+        "doctrine": "^1.2.2",
+        "jsx-ast-utils": "^1.2.1"
       },
       "dependencies": {
         "doctrine": {
@@ -10713,8 +6660,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         },
         "esutils": {
@@ -10738,71 +6685,82 @@
       }
     },
     "esprima": {
-      "version": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
       "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
     },
     "esutils": {
-      "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "exenv": {
-      "version": "https://registry.npmjs.org/exenv/-/exenv-1.2.1.tgz",
-      "integrity": "sha1-dd4cje4C6VKxAqoX+IdZc+DfFPk="
-    },
-    "expand-template": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
-      "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ==",
-      "dev": true
-    },
-    "extract-text-webpack-plugin": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-0.8.2.tgz",
-      "integrity": "sha1-STCd8yX1Ov/FOXL3Ea+6I2DBkUw=",
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "loader-utils": "0.2.17"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "exenv": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.1.tgz",
+      "integrity": "sha1-dd4cje4C6VKxAqoX+IdZc+DfFPk="
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extract-text-webpack-plugin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-1.0.1.tgz",
+      "integrity": "sha1-yVvzy6rEnclvHcbgclSfu2VMzSw=",
+      "dev": true,
+      "requires": {
+        "async": "^1.5.0",
+        "loader-utils": "^0.2.3",
+        "webpack-sources": "^0.1.0"
+      }
+    },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
       },
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "big.js": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-          "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-          "dev": true
-        },
-        "emojis-list": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-          "dev": true
-        },
-        "json5": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-          "dev": true
-        },
-        "loader-utils": {
-          "version": "0.2.17",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "dev": true,
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
+            "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "1.0.0",
@@ -10810,13 +6768,26 @@
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
       "dev": true
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
     "file-loader": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
       "integrity": "sha1-knXQMf54DyfUf19K8CvUNxPMFRs=",
       "dev": true,
       "requires": {
-        "loader-utils": "0.2.17"
+        "loader-utils": "~0.2.5"
       },
       "dependencies": {
         "big.js": {
@@ -10843,46 +6814,88 @@
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "dev": true,
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
           }
         }
       }
     },
     "find-up": {
-      "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
       "requires": {
-        "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+        "locate-path": "^3.0.0"
+      }
+    },
+    "flora-colossus": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/flora-colossus/-/flora-colossus-1.0.1.tgz",
+      "integrity": "sha512-d+9na7t9FyH8gBJoNDSi28mE4NgQVGGvxQ4aHtFRetjyh5SXjuus+V5EZaxFmFdXVemSOrx0lsgEl/ZMjnOWJA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.0"
       },
       "dependencies": {
-        "path-exists": {
-          "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
           "dev": true,
           "requires": {
-            "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         }
       }
     },
     "forever-agent": {
-      "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-      "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
       "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+          "dev": true
+        }
+      }
+    },
+    "fs-extra-p": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-8.1.0.tgz",
+      "integrity": "sha512-sCLpU5kk5CvrWZvFM9dUlqPgHrE02AEt6XYzF7kDscr5COc7DHfhNfODTXt0bkVNmt5DkvU2uJSYjorxY3bRKA==",
+      "dev": true,
+      "requires": {
+        "bluebird-lst": "^1.0.9",
+        "fs-extra": "^8.1.0"
       }
     },
     "fs.realpath": {
@@ -10890,49 +6903,189 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "gauge": {
-      "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+    "galactus": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/galactus/-/galactus-0.2.1.tgz",
+      "integrity": "sha1-y+0tIKQMH1Z5o1kI4rlBVzPnjbk=",
       "dev": true,
       "requires": {
-        "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
-        "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-        "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-        "object-assign": "4.1.1",
-        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-        "wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
-      }
-    },
-    "generate-function": {
-      "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
-    },
-    "generate-object-property": {
-      "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+        "debug": "^3.1.0",
+        "flora-colossus": "^1.0.0",
+        "fs-extra": "^4.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        }
       }
     },
     "get-caller-file": {
-      "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-package-info": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-package-info/-/get-package-info-1.0.0.tgz",
+      "integrity": "sha1-ZDJ5ZWPigRPNlHTbvQAFKYWkmZw=",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.1.1",
+        "debug": "^2.2.0",
+        "lodash.get": "^4.0.0",
+        "read-pkg-up": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
     },
     "get-stdin": {
-      "version": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
-    "github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-      "dev": true
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "github-latest-release": {
       "version": "0.1.1",
@@ -10940,10 +7093,10 @@
       "integrity": "sha1-j9m9LV7y1aDAdNkdYy6mBmk10UA=",
       "dev": true,
       "requires": {
-        "bluebird": "2.11.0",
-        "lodash.pick": "3.1.0",
-        "meow": "3.7.0",
-        "request": "2.83.0"
+        "bluebird": "^2.9.27",
+        "lodash.pick": "^3.1.0",
+        "meow": "^3.0.0",
+        "request": "^2.56.0"
       },
       "dependencies": {
         "ajv": {
@@ -10952,10 +7105,10 @@
           "integrity": "sha1-Pa+ai2ciEpn9ro2C0RftjmyAJEs=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "0.3.1",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "json-schema-traverse": "^0.3.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "array-find-index": {
@@ -11001,7 +7154,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "bluebird": {
@@ -11016,7 +7169,7 @@
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         },
         "builtin-modules": {
@@ -11037,8 +7190,8 @@
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
           }
         },
         "caseless": {
@@ -11059,7 +7212,7 @@
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "core-util-is": {
@@ -11074,7 +7227,7 @@
           "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
           "dev": true,
           "requires": {
-            "boom": "5.2.0"
+            "boom": "5.x.x"
           },
           "dependencies": {
             "boom": {
@@ -11083,7 +7236,7 @@
               "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
               "dev": true,
               "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.x.x"
               }
             }
           }
@@ -11094,7 +7247,7 @@
           "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
           "dev": true,
           "requires": {
-            "array-find-index": "1.0.2"
+            "array-find-index": "^1.0.1"
           }
         },
         "dashdash": {
@@ -11103,7 +7256,7 @@
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "decamelize": {
@@ -11125,7 +7278,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "error-ex": {
@@ -11134,7 +7287,7 @@
           "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
           "dev": true,
           "requires": {
-            "is-arrayish": "0.2.1"
+            "is-arrayish": "^0.2.1"
           }
         },
         "extend": {
@@ -11155,8 +7308,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "forever-agent": {
@@ -11171,9 +7324,9 @@
           "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "get-stdin": {
@@ -11188,7 +7341,7 @@
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -11209,8 +7362,8 @@
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "dev": true,
           "requires": {
-            "ajv": "5.2.4",
-            "har-schema": "2.0.0"
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
           }
         },
         "hawk": {
@@ -11219,10 +7372,10 @@
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
           "dev": true,
           "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.0.2"
+            "boom": "4.x.x",
+            "cryptiles": "3.x.x",
+            "hoek": "4.x.x",
+            "sntp": "2.x.x"
           }
         },
         "hoek": {
@@ -11243,9 +7396,9 @@
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "indent-string": {
@@ -11254,7 +7407,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "is-arrayish": {
@@ -11269,7 +7422,7 @@
           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true,
           "requires": {
-            "builtin-modules": "1.1.1"
+            "builtin-modules": "^1.0.0"
           }
         },
         "is-finite": {
@@ -11278,7 +7431,7 @@
           "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -11324,7 +7477,7 @@
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -11357,11 +7510,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "lodash._baseflatten": {
@@ -11370,8 +7523,8 @@
           "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
           "dev": true,
           "requires": {
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
           }
         },
         "lodash._basefor": {
@@ -11398,8 +7551,8 @@
           "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
           "dev": true,
           "requires": {
-            "lodash._basefor": "3.0.3",
-            "lodash.keysin": "3.0.8"
+            "lodash._basefor": "^3.0.0",
+            "lodash.keysin": "^3.0.0"
           }
         },
         "lodash.isarguments": {
@@ -11420,8 +7573,8 @@
           "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
           "dev": true,
           "requires": {
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
           }
         },
         "lodash.pick": {
@@ -11430,11 +7583,11 @@
           "integrity": "sha1-8lKoVbIEa2G805BLJvdr0u/GVVA=",
           "dev": true,
           "requires": {
-            "lodash._baseflatten": "3.1.4",
-            "lodash._bindcallback": "3.0.1",
-            "lodash._pickbyarray": "3.0.2",
-            "lodash._pickbycallback": "3.0.0",
-            "lodash.restparam": "3.6.1"
+            "lodash._baseflatten": "^3.0.0",
+            "lodash._bindcallback": "^3.0.0",
+            "lodash._pickbyarray": "^3.0.0",
+            "lodash._pickbycallback": "^3.0.0",
+            "lodash.restparam": "^3.0.0"
           }
         },
         "lodash.restparam": {
@@ -11449,8 +7602,8 @@
           "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
           "dev": true,
           "requires": {
-            "currently-unhandled": "0.4.1",
-            "signal-exit": "3.0.2"
+            "currently-unhandled": "^0.4.1",
+            "signal-exit": "^3.0.0"
           }
         },
         "map-obj": {
@@ -11465,16 +7618,16 @@
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.4.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
           }
         },
         "mime-db": {
@@ -11489,7 +7642,7 @@
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "dev": true,
           "requires": {
-            "mime-db": "1.30.0"
+            "mime-db": "~1.30.0"
           }
         },
         "normalize-package-data": {
@@ -11498,10 +7651,10 @@
           "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "number-is-nan": {
@@ -11522,7 +7675,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -11531,7 +7684,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -11540,9 +7693,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "performance-now": {
@@ -11569,7 +7722,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "punycode": {
@@ -11590,9 +7743,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -11601,8 +7754,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "redent": {
@@ -11611,8 +7764,8 @@
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "dev": true,
           "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
           }
         },
         "repeating": {
@@ -11621,7 +7774,7 @@
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "request": {
@@ -11630,28 +7783,28 @@
           "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           }
         },
         "safe-buffer": {
@@ -11678,7 +7831,7 @@
           "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         },
         "spdx-correct": {
@@ -11687,7 +7840,7 @@
           "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
           "dev": true,
           "requires": {
-            "spdx-license-ids": "1.2.2"
+            "spdx-license-ids": "^1.0.2"
           }
         },
         "spdx-expression-parse": {
@@ -11708,14 +7861,14 @@
           "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
           "dev": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
           }
         },
         "stringstream": {
@@ -11730,7 +7883,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-indent": {
@@ -11739,7 +7892,7 @@
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1"
+            "get-stdin": "^4.0.1"
           }
         },
         "tough-cookie": {
@@ -11748,7 +7901,7 @@
           "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
           "dev": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "trim-newlines": {
@@ -11763,7 +7916,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -11779,8 +7932,8 @@
           "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "dev": true,
           "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
+            "spdx-correct": "~1.0.0",
+            "spdx-expression-parse": "~1.0.0"
           }
         },
         "verror": {
@@ -11789,31 +7942,32 @@
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
+            "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
+            "extsprintf": "^1.2.0"
           }
         }
       }
     },
     "glob": {
-      "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
       "requires": {
-        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "global-dirs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.0.tgz",
-      "integrity": "sha1-ENNAOeDfBCcuJizyQiT3IJQ0308=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+        "ini": "^1.3.4"
       }
     },
     "globals": {
@@ -11821,189 +7975,262 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
       "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08="
     },
+    "got": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
     "graceful-fs": {
-      "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
-      "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "graphiql": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/graphiql/-/graphiql-0.11.11.tgz",
-      "integrity": "sha512-+r8qY2JRRs+uaZcrZOxpNhdlCZoS8yS5KQ6X53Twc8WecZ6VtAn+MVHroLOd4u9HVPxTXZ9RUd9+556EpTc0xA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/graphiql/-/graphiql-0.12.0.tgz",
+      "integrity": "sha512-OM5dpcONLK1B2prez2WVTfohQlQKe4Fwv1YwNQYQhN+fFGEW87D5v5fN2M8ZebzxbZHqP12KkHicO3sv8k30TQ==",
       "requires": {
-        "codemirror": "5.34.0",
-        "codemirror-graphql": "0.6.12",
-        "markdown-it": "8.4.1"
+        "codemirror": "^5.26.0",
+        "codemirror-graphql": "^0.7.1",
+        "markdown-it": "^8.4.0"
       }
     },
+    "graphiql-explorer": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/graphiql-explorer/-/graphiql-explorer-0.4.4.tgz",
+      "integrity": "sha512-NuQ1XAjZwykKb9GoHM6ofI9qITZ8Lue/mXi1Bj3/ZbGZv1Srk3sz0QkKQ5jBaxmuS3Ay09LRvJQSOr0Ci1dlfg==",
+      "dev": true
+    },
     "graphql": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.13.0.tgz",
-      "integrity": "sha512-WlO+ZJT9aY3YrBT+H5Kk+eVb3OVVehB9iRD/xqeHdmrrn4AFl5FIcOpfHz/vnBr6Y6JthGMlnFqU8XRnDjSR7A==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
+      "integrity": "sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==",
       "requires": {
-        "iterall": "1.1.3"
+        "iterall": "^1.2.1"
       }
     },
     "graphql-config": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-1.1.4.tgz",
-      "integrity": "sha512-OwDrKrYc1h7HHhEVInQrKInl7/ZgfT4ftjjBJDahBiiHi/mEstnn0mVlSb7B06SF+PZt/FgkE3q+RX+rqavvWQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-2.0.1.tgz",
+      "integrity": "sha512-eb4FzlODifHE/Q+91QptAmkGw39wL5ToinJ2556UUsGt2drPc4tzifL+HSnHSaxiIbH8EUhc/Fa6+neinF04qA==",
       "requires": {
-        "graphql": "0.12.3",
-        "graphql-import": "0.1.9",
-        "graphql-request": "1.4.1",
-        "js-yaml": "3.10.0",
-        "minimatch": "3.0.4",
-        "rimraf": "2.6.2"
+        "graphql-import": "^0.4.4",
+        "graphql-request": "^1.5.0",
+        "js-yaml": "^3.10.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4"
       },
       "dependencies": {
-        "graphql": {
-          "version": "0.12.3",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.12.3.tgz",
-          "integrity": "sha512-Hn9rdu4zacplKXNrLCvR8YFiTGnbM4Zw/UH8FDmzBDsH7ou40lSNH4tIlsxcYnz2TGNVJCpu1WxCM23yd6kzhA==",
-          "requires": {
-            "iterall": "1.1.3"
-          }
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
     },
     "graphql-import": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.1.9.tgz",
-      "integrity": "sha512-syHe1DlzOQScChjU21J/dSAcOh7T2ikr/5QGw1TQCzLR96WQ+95Suitt7TjcT3NA1/uBq/hc70MgxvJrFWdWAg==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.4.5.tgz",
+      "integrity": "sha512-G/+I08Qp6/QGTb9qapknCm3yPHV0ZL7wbaalWFpxsfR8ZhZoTBe//LsbsCKlbALQpcMegchpJhpTSKiJjhaVqQ==",
       "requires": {
-        "@types/graphql": "0.11.7",
-        "@types/lodash": "4.14.102",
-        "graphql": "0.12.3",
-        "lodash": "4.17.5"
+        "lodash": "^4.17.4"
       },
       "dependencies": {
-        "graphql": {
-          "version": "0.12.3",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.12.3.tgz",
-          "integrity": "sha512-Hn9rdu4zacplKXNrLCvR8YFiTGnbM4Zw/UH8FDmzBDsH7ou40lSNH4tIlsxcYnz2TGNVJCpu1WxCM23yd6kzhA==",
-          "requires": {
-            "iterall": "1.1.3"
-          }
-        },
         "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         }
       }
     },
     "graphql-language-service-interface": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-interface/-/graphql-language-service-interface-1.0.18.tgz",
-      "integrity": "sha512-qXCCd6PUqogWcdkeK/CqP56RpNFZHjq3moIDpvRf/D3qjJGe7b8ryfagU3KEKuDbx72l4qDsw+dBfNd8QzDaYw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-interface/-/graphql-language-service-interface-1.3.2.tgz",
+      "integrity": "sha512-sOxFV5sBSnYtKIFHtlmAHHVdhok7CRbvCPLcuHvL4Q1RSgKRsPpeHUDKU+yCbmlonOKn/RWEKaYWrUY0Sgv70A==",
       "requires": {
-        "graphql-config": "1.1.4",
-        "graphql-language-service-parser": "1.0.18",
-        "graphql-language-service-types": "1.0.18",
-        "graphql-language-service-utils": "1.0.18"
+        "graphql-config": "2.0.1",
+        "graphql-language-service-parser": "^1.2.2",
+        "graphql-language-service-types": "^1.2.2",
+        "graphql-language-service-utils": "^1.2.2"
+      }
+    },
+    "graphql-language-service-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-1.3.0.tgz",
+      "integrity": "sha512-IVW5EQts6CCm6G1pJzyOSNGv28Ia1afyx7gGIhDQkbXbNmShbNOneUWyURbawX9fL2A1AGhdA80fuCSLO8Jb9Q==",
+      "requires": {
+        "graphql-config": "2.2.1",
+        "graphql-language-service-types": "^1.3.0"
       },
       "dependencies": {
-        "graphql-language-service-parser": {
-          "version": "1.0.18",
-          "resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-1.0.18.tgz",
-          "integrity": "sha512-ysaySmwF0kZX7nRVCCn4+U66JXF90wvEbhCZa0tHWvB98P8yNsLut91Kr7jdnuAZZOddFU+fRdNqcZavTOszGQ==",
+        "graphql-config": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-2.2.1.tgz",
+          "integrity": "sha512-U8+1IAhw9m6WkZRRcyj8ZarK96R6lQBQ0an4lp76Ps9FyhOXENC5YQOxOFGm5CxPrX2rD0g3Je4zG5xdNJjwzQ==",
           "requires": {
-            "graphql-config": "1.1.4",
-            "graphql-language-service-types": "1.0.18"
+            "graphql-import": "^0.7.1",
+            "graphql-request": "^1.5.0",
+            "js-yaml": "^3.10.0",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.4"
+          }
+        },
+        "graphql-import": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.7.1.tgz",
+          "integrity": "sha512-YpwpaPjRUVlw2SN3OPljpWbVRWAhMAyfSba5U47qGMOSsPLi2gYeJtngGpymjm9nk57RFWEpjqwh4+dpYuFAPw==",
+          "requires": {
+            "lodash": "^4.17.4",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         }
       }
     },
-    "graphql-language-service-parser": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-0.1.14.tgz",
-      "integrity": "sha512-72M4OksONeqT5slfdfODmlPBFlUQQkcnRhjgmPt9H2n8/DUcf4XzDkGXudBWpzNfjVU35+IADYW6x13wKw/fOg==",
+    "graphql-language-service-types": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-1.3.0.tgz",
+      "integrity": "sha512-agVSOtvr1qKgURsNONI7pY6xRshVTTxhBSUZvyNDFKYma1P/uWK9xVuPyU4zMuXeugaWNGysWAf4VgP8SnawxA==",
       "requires": {
-        "graphql-language-service-types": "0.1.14"
+        "graphql-config": "2.2.1"
       },
       "dependencies": {
-        "graphql-language-service-types": {
-          "version": "0.1.14",
-          "resolved": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-0.1.14.tgz",
-          "integrity": "sha512-77KP83gvK0gWswvGY/+jx/GpsOfKuwWQ1AYnyPT2GDGG3//1QxQTObaZMAEevNTxJtO8T26YXxoUlqkvET7iEg=="
+        "graphql-config": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-2.2.1.tgz",
+          "integrity": "sha512-U8+1IAhw9m6WkZRRcyj8ZarK96R6lQBQ0an4lp76Ps9FyhOXENC5YQOxOFGm5CxPrX2rD0g3Je4zG5xdNJjwzQ==",
+          "requires": {
+            "graphql-import": "^0.7.1",
+            "graphql-request": "^1.5.0",
+            "js-yaml": "^3.10.0",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.4"
+          }
+        },
+        "graphql-import": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.7.1.tgz",
+          "integrity": "sha512-YpwpaPjRUVlw2SN3OPljpWbVRWAhMAyfSba5U47qGMOSsPLi2gYeJtngGpymjm9nk57RFWEpjqwh4+dpYuFAPw==",
+          "requires": {
+            "lodash": "^4.17.4",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
         }
       }
     },
-    "graphql-language-service-types": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-1.0.18.tgz",
-      "integrity": "sha512-nZpTP6S5uSBSCsxW4BJ4/x04vNf5tKddUSC0YiXjgu7Hx+EeG8IHuP4QtB2gIWIZ0dYt7mtb7HrzNwlCcmsAvw==",
-      "requires": {
-        "graphql-config": "1.1.4"
-      }
-    },
     "graphql-language-service-utils": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-utils/-/graphql-language-service-utils-1.0.18.tgz",
-      "integrity": "sha512-Ip36GIhS1sZCJrB+ScWQbYG8sdWevv7n65BMkMdJZxiVAYLoKEvTwppehBwwBpRAUS/OBDAM9UPav4UE4IeVBQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-utils/-/graphql-language-service-utils-1.2.2.tgz",
+      "integrity": "sha512-98hzn1Dg3sSAiB+TuvNwWAoBrzuHs8NylkTK26TFyBjozM5wBZttp+T08OvOt+9hCFYRa43yRPrWcrs78KH9Hw==",
       "requires": {
-        "graphql-config": "1.1.4",
-        "graphql-language-service-types": "1.0.18"
+        "graphql-config": "2.0.1",
+        "graphql-language-service-types": "^1.2.2"
       }
     },
     "graphql-request": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-1.4.1.tgz",
-      "integrity": "sha1-B3J0PPrI391NadNhBqlsm90ZHOg=",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-1.8.2.tgz",
+      "integrity": "sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==",
       "requires": {
-        "cross-fetch": "1.1.1"
+        "cross-fetch": "2.2.2"
       }
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
     "har-validator": {
-      "version": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-      "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
-      "dev": true,
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
-        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-        "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz"
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
       }
     },
     "has-ansi": {
-      "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+        "ansi-regex": "^2.0.0"
       }
     },
-    "has-unicode": {
-      "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
-    "hawk": {
-      "version": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-      "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
-      "dev": true,
-      "requires": {
-        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-        "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-        "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-      }
-    },
-    "hoek": {
-      "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+    "has-yarn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
+      "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
       "dev": true
     },
     "home-or-tmp": {
@@ -12011,14 +8238,19 @@
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
       "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
       "requires": {
-        "os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-        "user-home": "1.1.1"
+        "os-tmpdir": "^1.0.1",
+        "user-home": "^1.1.1"
       }
     },
+    "home-path": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.6.tgz",
+      "integrity": "sha512-wo+yjrdAtoXt43Vy92a+0IPCYViiyLAHyp0QVS4xL/tfvVz5sXIW1ubLZk3nhVkD92fQpUMKX+fzMjr5F489vw=="
+    },
     "hosted-git-info": {
-      "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.1.tgz",
-      "integrity": "sha1-SwRF5BwASovRM3dzpP95DKQDGMg=",
-      "dev": true
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ=="
     },
     "html-loader": {
       "version": "0.3.0",
@@ -12026,10 +8258,10 @@
       "integrity": "sha1-l5pCfKOo5vx8W8t8L1qz6UDVKRc=",
       "dev": true,
       "requires": {
-        "fastparse": "1.1.1",
-        "html-minifier": "0.7.2",
-        "loader-utils": "0.2.17",
-        "source-map": "0.1.43"
+        "fastparse": "^1.0.0",
+        "html-minifier": "^0.7.2",
+        "loader-utils": "~0.2.2",
+        "source-map": "0.1.x"
       },
       "dependencies": {
         "amdefine": {
@@ -12056,8 +8288,8 @@
           "integrity": "sha1-Gsp8TRlTWaLOmVV5NDPG5VQlEfI=",
           "dev": true,
           "requires": {
-            "sentence-case": "1.1.3",
-            "upper-case": "1.1.3"
+            "sentence-case": "^1.1.1",
+            "upper-case": "^1.1.1"
           }
         },
         "camelcase": {
@@ -12072,22 +8304,22 @@
           "integrity": "sha1-LE/ePwY7tB0AzWjg1aCdthy+iU8=",
           "dev": true,
           "requires": {
-            "camel-case": "1.2.2",
-            "constant-case": "1.1.2",
-            "dot-case": "1.1.2",
-            "is-lower-case": "1.1.3",
-            "is-upper-case": "1.1.2",
-            "lower-case": "1.1.4",
-            "lower-case-first": "1.0.2",
-            "param-case": "1.1.2",
-            "pascal-case": "1.1.2",
-            "path-case": "1.1.2",
-            "sentence-case": "1.1.3",
-            "snake-case": "1.1.2",
-            "swap-case": "1.1.2",
-            "title-case": "1.1.2",
-            "upper-case": "1.1.3",
-            "upper-case-first": "1.1.2"
+            "camel-case": "^1.1.1",
+            "constant-case": "^1.1.0",
+            "dot-case": "^1.1.0",
+            "is-lower-case": "^1.1.0",
+            "is-upper-case": "^1.1.0",
+            "lower-case": "^1.1.1",
+            "lower-case-first": "^1.0.0",
+            "param-case": "^1.1.0",
+            "pascal-case": "^1.1.0",
+            "path-case": "^1.1.0",
+            "sentence-case": "^1.1.1",
+            "snake-case": "^1.1.0",
+            "swap-case": "^1.1.0",
+            "title-case": "^1.1.0",
+            "upper-case": "^1.1.1",
+            "upper-case-first": "^1.1.0"
           }
         },
         "clean-css": {
@@ -12096,8 +8328,8 @@
           "integrity": "sha1-29BaFIvklDuzfOBnnmdsvJ9YAmY=",
           "dev": true,
           "requires": {
-            "commander": "2.6.0",
-            "source-map": "0.1.43"
+            "commander": "2.6.x",
+            "source-map": ">=0.1.43 <0.2"
           }
         },
         "cli": {
@@ -12107,7 +8339,7 @@
           "dev": true,
           "requires": {
             "exit": "0.1.2",
-            "glob": "3.2.11"
+            "glob": "~ 3.2.1"
           }
         },
         "commander": {
@@ -12122,9 +8354,9 @@
           "integrity": "sha1-rMO79WAsuMyYDGrIQPp9hgPj7zY=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "1.1.14",
-            "typedarray": "0.0.6"
+            "inherits": "~2.0.1",
+            "readable-stream": "~1.1.9",
+            "typedarray": "~0.0.5"
           }
         },
         "constant-case": {
@@ -12133,8 +8365,8 @@
           "integrity": "sha1-jsLKW6ND4Aqjjb9OIA/VrJB+/WM=",
           "dev": true,
           "requires": {
-            "snake-case": "1.1.2",
-            "upper-case": "1.1.3"
+            "snake-case": "^1.1.0",
+            "upper-case": "^1.1.1"
           }
         },
         "core-util-is": {
@@ -12155,7 +8387,7 @@
           "integrity": "sha1-HnOCaQDeKNbeVIC8HeMdCEKwa+w=",
           "dev": true,
           "requires": {
-            "sentence-case": "1.1.3"
+            "sentence-case": "^1.1.2"
           }
         },
         "emojis-list": {
@@ -12182,8 +8414,8 @@
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
+            "inherits": "2",
+            "minimatch": "0.3"
           }
         },
         "html-minifier": {
@@ -12192,12 +8424,12 @@
           "integrity": "sha1-K3lZsQUaSB5xzXxuWaZCcq+JXP0=",
           "dev": true,
           "requires": {
-            "change-case": "2.3.1",
-            "clean-css": "3.1.9",
-            "cli": "0.6.6",
-            "concat-stream": "1.4.10",
-            "relateurl": "0.2.7",
-            "uglify-js": "2.4.24"
+            "change-case": "2.3.x",
+            "clean-css": "3.1.x",
+            "cli": "0.6.x",
+            "concat-stream": "1.4.x",
+            "relateurl": "0.2.x",
+            "uglify-js": "2.4.x"
           }
         },
         "inherits": {
@@ -12212,7 +8444,7 @@
           "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
           "dev": true,
           "requires": {
-            "lower-case": "1.1.4"
+            "lower-case": "^1.1.0"
           }
         },
         "is-upper-case": {
@@ -12221,7 +8453,7 @@
           "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
           "dev": true,
           "requires": {
-            "upper-case": "1.1.3"
+            "upper-case": "^1.1.0"
           }
         },
         "isarray": {
@@ -12242,10 +8474,10 @@
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "dev": true,
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
           }
         },
         "lower-case": {
@@ -12260,7 +8492,7 @@
           "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
           "dev": true,
           "requires": {
-            "lower-case": "1.1.4"
+            "lower-case": "^1.1.2"
           }
         },
         "lru-cache": {
@@ -12275,8 +8507,8 @@
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         },
         "param-case": {
@@ -12285,7 +8517,7 @@
           "integrity": "sha1-3LCRpDwlm5Io8cNB57akTqC/l0M=",
           "dev": true,
           "requires": {
-            "sentence-case": "1.1.3"
+            "sentence-case": "^1.1.2"
           }
         },
         "pascal-case": {
@@ -12294,8 +8526,8 @@
           "integrity": "sha1-Pl1kogBDgwp8STRMLXS0G+DJyZs=",
           "dev": true,
           "requires": {
-            "camel-case": "1.2.2",
-            "upper-case-first": "1.1.2"
+            "camel-case": "^1.1.1",
+            "upper-case-first": "^1.1.0"
           }
         },
         "path-case": {
@@ -12304,7 +8536,7 @@
           "integrity": "sha1-UM5roNO+090LXCqcRVNpdDRAlRQ=",
           "dev": true,
           "requires": {
-            "sentence-case": "1.1.3"
+            "sentence-case": "^1.1.2"
           }
         },
         "readable-stream": {
@@ -12313,10 +8545,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "relateurl": {
@@ -12331,7 +8563,7 @@
           "integrity": "sha1-gDSq/CFFdy06vhUJqkLJ4QQtwTk=",
           "dev": true,
           "requires": {
-            "lower-case": "1.1.4"
+            "lower-case": "^1.1.1"
           }
         },
         "sigmund": {
@@ -12346,7 +8578,7 @@
           "integrity": "sha1-DC8l4wUVjZoY09l3BmGH/vilpmo=",
           "dev": true,
           "requires": {
-            "sentence-case": "1.1.3"
+            "sentence-case": "^1.1.2"
           }
         },
         "source-map": {
@@ -12355,7 +8587,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "string_decoder": {
@@ -12370,8 +8602,8 @@
           "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
           "dev": true,
           "requires": {
-            "lower-case": "1.1.4",
-            "upper-case": "1.1.3"
+            "lower-case": "^1.1.1",
+            "upper-case": "^1.1.1"
           }
         },
         "title-case": {
@@ -12380,8 +8612,8 @@
           "integrity": "sha1-+uSmrlRr+iLQg6DuqRCkDRLtT1o=",
           "dev": true,
           "requires": {
-            "sentence-case": "1.1.3",
-            "upper-case": "1.1.3"
+            "sentence-case": "^1.1.1",
+            "upper-case": "^1.0.3"
           }
         },
         "typedarray": {
@@ -12396,10 +8628,10 @@
           "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
           "dev": true,
           "requires": {
-            "async": "0.2.10",
+            "async": "~0.2.6",
             "source-map": "0.1.34",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.5.4"
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.5.4"
           },
           "dependencies": {
             "source-map": {
@@ -12408,7 +8640,7 @@
               "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
               "dev": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
               }
             }
           }
@@ -12431,7 +8663,7 @@
           "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
           "dev": true,
           "requires": {
-            "upper-case": "1.1.3"
+            "upper-case": "^1.1.1"
           }
         },
         "window-size": {
@@ -12452,13 +8684,19 @@
           "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0",
             "wordwrap": "0.0.2"
           }
         }
       }
+    },
+    "http-cache-semantics": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
+      "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
+      "dev": true
     },
     "http-parser-js": {
       "version": "0.4.9",
@@ -12467,17 +8705,18 @@
       "dev": true
     },
     "http-signature": {
-      "version": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-      "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
-      "dev": true,
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-        "ctype": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
-      "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
       "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
     },
     "ignore-loader": {
@@ -12486,87 +8725,92 @@
       "integrity": "sha1-2B8kA3bQuk8Nd4lyw60lh0EXpGM=",
       "dev": true
     },
+    "import-lazy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true
+    },
     "imurmurhash": {
-      "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "indent-string": {
-      "version": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true,
       "requires": {
-        "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+        "repeating": "^2.0.0"
       },
       "dependencies": {
         "repeating": {
-          "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-          "dev": true,
           "requires": {
-            "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+            "is-finite": "^1.0.0"
           }
         }
       }
     },
     "inflight": {
-      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
-      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-      "dev": true
-    },
-    "int64-buffer": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.9.tgz",
-      "integrity": "sha1-ngOdoEOyT3ixlrKD4EZT716ZD2E=",
-      "dev": true
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "invert-kv": {
-      "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "is-arrayish": {
-      "version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-buffer": {
-      "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
     },
-    "is-builtin-module": {
-      "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+    "is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "dev": true,
       "requires": {
-        "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+        "ci-info": "^2.0.0"
       }
     },
     "is-finite": {
-      "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
-      "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-installed-globally": {
       "version": "0.1.0",
@@ -12574,8 +8818,8 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "0.1.0",
-        "is-path-inside": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-integer": {
@@ -12583,54 +8827,72 @@
       "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
       "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
       "requires": {
-        "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+        "is-finite": "^1.0.0"
       }
     },
-    "is-my-json-valid": {
-      "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true,
-      "requires": {
-        "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-        "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-        "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-      }
-    },
-    "is-path-inside": {
-      "version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
-      }
-    },
-    "is-property": {
-      "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+    "is-npm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
+      "integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA==",
       "dev": true
     },
-    "is-redirect": {
-      "version": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.1"
+      }
+    },
+    "is-promise": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
+      "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU=",
       "dev": true
     },
     "is-stream": {
-      "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
-      "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "is-yarn-global": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
     },
     "isarray": {
-      "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "isbinaryfile": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.2.tgz",
+      "integrity": "sha512-C3FSxJdNrEr2F4z6uFtNzECDM5hXk+46fxaa+cwBe5/XrWSmzdG8DDgyjfX6/NRdBB21q2JXuRAzPCUs+fclnQ==",
       "dev": true
     },
     "isexe": {
-      "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
@@ -12639,8 +8901,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       },
       "dependencies": {
         "encoding": {
@@ -12648,7 +8910,7 @@
           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
           "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
           "requires": {
-            "iconv-lite": "0.4.19"
+            "iconv-lite": "~0.4.13"
           }
         },
         "iconv-lite": {
@@ -12666,8 +8928,8 @@
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
           "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
           "requires": {
-            "encoding": "0.1.12",
-            "is-stream": "1.1.0"
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
           }
         },
         "whatwg-fetch": {
@@ -12678,14 +8940,14 @@
       }
     },
     "isstream": {
-      "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "iterall": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
-      "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
     },
     "js-tokens": {
       "version": "1.0.1",
@@ -12693,25 +8955,36 @@
       "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4="
     },
     "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
-        "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "dependencies": {
         "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         }
       }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jschardet": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
       "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
+      "dev": true
+    },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
     },
     "json-loader": {
@@ -12720,61 +8993,97 @@
       "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
       "dev": true
     },
-    "json-schema-traverse": {
-      "version": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
-    "json-stable-stringify": {
-      "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-      }
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
-      "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
       "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
     },
-    "jsonify": {
-      "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
-    "jsonpointer": {
-      "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
     },
     "kind-of": {
-      "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
       "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
       "requires": {
-        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+        "is-buffer": "^1.0.2"
+      }
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
+    "latest-version": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
+      "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
+      "dev": true,
+      "requires": {
+        "package-json": "^6.3.0"
       }
     },
     "lazy-cache": {
-      "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
     "lazy-val": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.2.tgz",
-      "integrity": "sha512-2BaSu6qVnicKdWQPysrffZVFAKcPcZQ/q2YyeSjAxWaJlvCvKSrkcvsSHlleeIfA//fW2goTcYDTy2cBLN7+PQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.4.tgz",
+      "integrity": "sha512-u93kb2fPbIrfzBuLjZE+w+fJbUUMhNDXxNmMfaqNgpfQf1CO5ZSe2LfsnBqVAk7i/2NF48OSoRj+Xe2VT+lE8Q==",
       "dev": true
     },
     "lcid": {
-      "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+        "invert-kv": "^1.0.0"
       }
     },
     "leven": {
@@ -12783,23 +9092,50 @@
       "integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM="
     },
     "linkify-it": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
-      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
       "requires": {
-        "uc.micro": "1.0.5"
+        "uc.micro": "^1.0.1"
       }
     },
     "load-json-file": {
-      "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
+      }
+    },
+    "loader-utils": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+      "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
       "dev": true,
       "requires": {
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+          "dev": true
+        }
       }
     },
     "loaders-by-extension": {
@@ -12808,65 +9144,98 @@
       "integrity": "sha1-YphC1Jm52ABJ3LZV4QC/fHi3Cz8=",
       "dev": true
     },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
     "lodash": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
     },
-    "lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "longest": {
-      "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loose-envify": {
-      "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+        "js-tokens": "^3.0.0"
       },
       "dependencies": {
         "js-tokens": {
-          "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
           "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
           "dev": true
         }
       }
     },
     "loud-rejection": {
-      "version": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true,
       "requires": {
-        "currently-unhandled": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-        "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lowercase-keys": {
-      "version": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      }
     },
     "map-obj": {
-      "version": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
     "markdown-it": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.1.tgz",
-      "integrity": "sha512-CzzqSSNkFRUf9vlWvhK1awpJreMRqdCrBvZ8DIoDWTOkESMIF741UPAhuAmbyWmdiFPA6WARNhnu2M6Nrhwa+A==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
       "requires": {
-        "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-        "entities": "1.1.1",
-        "linkify-it": "2.0.3",
-        "mdurl": "1.0.1",
-        "uc.micro": "1.0.5"
+        "argparse": "^1.0.7",
+        "entities": "~1.1.1",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
       }
     },
     "mdurl": {
@@ -12875,63 +9244,113 @@
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "meow": {
-      "version": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "dev": true,
       "requires": {
-        "camelcase-keys": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-        "loud-rejection": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-        "map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-        "minimist": "1.2.0",
-        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-        "redent": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-        "trim-newlines": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       }
     },
-    "mime-db": {
-      "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-      "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc=",
+    "mime": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
       "dev": true
     },
+    "mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+    },
     "mime-types": {
-      "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-      "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
-      "dev": true,
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "requires": {
-        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+        "mime-db": "1.40.0"
       }
     },
-    "mimic-fn": {
-      "version": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
     "minimatch": {
-      "version": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
       "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
       "requires": {
-        "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
+        "brace-expansion": "^1.0.0"
       }
     },
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
-      "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        "minimist": "0.0.8"
       },
       "dependencies": {
         "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
+    "mkpath": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+      "integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE=",
+      "dev": true
+    },
+    "mksnapshot": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.3.5.tgz",
+      "integrity": "sha512-PSBoZaj9h9myC3uRRW62RxmX8mrN3XbOkMEyURUD7v5CeJgtYTar50XU738t7Q0LtG1pBPtp5n5QwDGggRnEvw==",
+      "dev": true,
+      "requires": {
+        "decompress-zip": "0.3.x",
+        "fs-extra": "0.26.7",
+        "request": "2.x"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "0.26.7",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+          "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
         }
       }
     },
@@ -12986,8 +9405,8 @@
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
+            "inherits": "2",
+            "minimatch": "0.3"
           }
         },
         "growl": {
@@ -13038,8 +9457,8 @@
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         },
         "minimist": {
@@ -13088,56 +9507,100 @@
       "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.1.tgz",
       "integrity": "sha1-KghfXHUSlMdefoH27CVFspy/Qtk="
     },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+    },
+    "nodeify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
+      "integrity": "sha1-ZKtpp7268DzhB7TwM1yHwLnpGx0=",
+      "dev": true,
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+        "is-promise": "~1.0.0",
+        "promise": "~1.3.0"
       }
     },
-    "node-uuid": {
-      "version": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-      "dev": true
-    },
-    "noop-logger": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
-      "dev": true
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
     },
     "normalize-package-data": {
-      "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
-      "integrity": "sha1-SY+kIMlkAfeHQCuiHmAN75+YH/8=",
-      "dev": true,
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "requires": {
-        "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.1.tgz",
-        "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-        "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
-    "npmlog": {
-      "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+    "normalize-url": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
+      "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
+      "dev": true
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-        "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-        "gauge": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-        "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+        "path-key": "^2.0.0"
+      }
+    },
+    "nugget": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
+      "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
+      "requires": {
+        "debug": "^2.1.3",
+        "minimist": "^1.1.0",
+        "pretty-bytes": "^1.0.2",
+        "progress-stream": "^1.1.0",
+        "request": "^2.45.0",
+        "single-line-log": "^1.1.2",
+        "throttleit": "0.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "number-is-nan": {
-      "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth-sign": {
-      "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-      "integrity": "sha1-fb6uRPbKRU4fFoRR1jB0ZzWBPOM=",
-      "dev": true
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -13145,140 +9608,245 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-keys": {
-      "version": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-      "dev": true
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
     },
     "once": {
-      "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+        "wrappy": "1"
       }
     },
     "os-homedir": {
-      "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-tmpdir": {
-      "version": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
-    "parse-json": {
-      "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
-      "requires": {
-        "error-ex": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
-      }
-    },
-    "path-is-absolute": {
-      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-    },
-    "path-is-inside": {
-      "version": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+    "p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
       "dev": true
     },
-    "path-type": {
-      "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-        "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-        "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-      }
-    },
-    "pify": {
-      "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
-    "pinkie": {
-      "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+    "p-limit": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
       "dev": true,
       "requires": {
-        "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+        "p-try": "^2.0.0"
       }
     },
-    "prebuild-install": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.3.0.tgz",
-      "integrity": "sha512-gzjq2oHB8oMbzJSsSh9MQ64zrXZGt092/uT4TLZlz2qnrPxpWqp4vYB7LZrDxnlxf5RfbCjkgDI/z0EIVuYzAw==",
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
       "requires": {
-        "expand-template": "1.1.0",
-        "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "node-abi": "2.1.1",
-        "noop-logger": "0.1.1",
-        "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-        "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-        "pump": "1.0.2",
-        "rc": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-        "simple-get": "1.4.3",
-        "tar-fs": "1.16.0",
-        "tunnel-agent": "0.6.0",
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "package-json": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
+      "dev": true,
+      "requires": {
+        "got": "^9.6.0",
+        "registry-auth-token": "^4.0.0",
+        "registry-url": "^5.0.0",
+        "semver": "^6.2.0"
       },
       "dependencies": {
-        "node-abi": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.1.tgz",
-          "integrity": "sha512-6oxV13poCOv7TfGvhsSz6XZWpXeKkdGVh72++cs33OfMh3KAX8lN84dCvmqSETyDXAFcUHtV7eJrgFBoOqZbNQ==",
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
-          }
         }
       }
     },
+    "parse-author": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-author/-/parse-author-2.0.0.tgz",
+      "integrity": "sha1-00YL8d3Q367tQtp1QkLmX7aEqB8=",
+      "dev": true,
+      "requires": {
+        "author-regex": "^1.0.0"
+      }
+    },
+    "parse-color": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
+      "integrity": "sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=",
+      "dev": true,
+      "requires": {
+        "color-convert": "~0.5.0"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
+          "dev": true
+        }
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
+      }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "plist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
+      "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^9.0.7",
+        "xmldom": "0.1.x"
+      }
+    },
     "prepend-http": {
-      "version": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
     "pretty-bytes": {
-      "version": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
       "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
-      "dev": true,
       "requires": {
-        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-        "meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
+        "get-stdin": "^4.0.1",
+        "meow": "^3.1.0"
       }
     },
     "private": {
-      "version": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
       "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
     },
     "process-nextick-args": {
-      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress-stream": {
-      "version": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
       "integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
+      "requires": {
+        "speedometer": "~0.1.2",
+        "through2": "~0.2.3"
+      }
+    },
+    "promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
+      "integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
       "dev": true,
       "requires": {
-        "speedometer": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
-        "through2": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz"
+        "is-promise": "~1"
       }
     },
     "prop-types": {
@@ -13286,9 +9854,9 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
       "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       },
       "dependencies": {
         "asap": {
@@ -13306,13 +9874,13 @@
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
           "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
           "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.17"
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.9"
           }
         },
         "js-tokens": {
@@ -13325,7 +9893,7 @@
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "promise": {
@@ -13333,7 +9901,7 @@
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
           "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
           "requires": {
-            "asap": "2.0.6"
+            "asap": "~2.0.3"
           }
         },
         "setimmediate": {
@@ -13348,71 +9916,53 @@
         }
       }
     },
-    "pump": {
+    "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.0",
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-      },
-      "dependencies": {
-        "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-          "dev": true,
-          "requires": {
-            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-          }
-        }
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "punycode": {
-      "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
-      "version": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
       "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
     },
     "qs": {
-      "version": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-      "integrity": "sha1-9854jld33wtQENp/fE5zujJHD1o=",
-      "dev": true
-    },
-    "rabin-bindings": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/rabin-bindings/-/rabin-bindings-1.7.3.tgz",
-      "integrity": "sha512-zeVdstq+EWdwQ5JCyuuvOsP2fmGc6993laN+v8eEQsahHwZCy8bt5TefohUpgsetiwQhMMk/o+m/2sYng13Txw==",
-      "dev": true,
-      "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.7.0",
-        "prebuild-install": "2.3.0"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-          "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
-          "dev": true
-        }
-      }
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "radium": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/radium/-/radium-0.14.3.tgz",
       "integrity": "sha1-6cqNzwQtGHu6sAK9tcxtpzaju3M=",
       "requires": {
-        "array-find": "1.0.0",
-        "babel": "5.8.38",
-        "babel-plugin-flow-comments": "1.0.9",
-        "exenv": "1.2.2",
-        "is-plain-object": "2.0.4",
-        "rimraf": "2.6.2"
+        "array-find": "^1.0.0",
+        "babel": "^5.8.23",
+        "babel-plugin-flow-comments": "^1.0.9",
+        "exenv": "^1.2.0",
+        "is-plain-object": "^2.0.1",
+        "rimraf": "^2.4.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -13430,8 +9980,8 @@
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
           "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
           "requires": {
-            "micromatch": "2.3.11",
-            "normalize-path": "2.1.1"
+            "micromatch": "^2.1.5",
+            "normalize-path": "^2.0.0"
           }
         },
         "arr-diff": {
@@ -13439,7 +9989,7 @@
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "arr-flatten": {
@@ -13467,18 +10017,18 @@
           "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.38.tgz",
           "integrity": "sha1-37CHwiiUkXxXb7Z86c8yjUWGKfs=",
           "requires": {
-            "babel-core": "5.8.38",
-            "chokidar": "1.7.0",
-            "commander": "2.11.0",
-            "convert-source-map": "1.5.0",
-            "fs-readdir-recursive": "0.1.2",
-            "glob": "5.0.15",
-            "lodash": "3.10.1",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "slash": "1.0.0",
-            "source-map": "0.5.7"
+            "babel-core": "^5.6.21",
+            "chokidar": "^1.0.0",
+            "commander": "^2.6.0",
+            "convert-source-map": "^1.1.0",
+            "fs-readdir-recursive": "^0.1.0",
+            "glob": "^5.0.5",
+            "lodash": "^3.2.0",
+            "output-file-sync": "^1.1.0",
+            "path-exists": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.0"
           }
         },
         "babel-core": {
@@ -13486,52 +10036,52 @@
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
           "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
           "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "1.5.0",
-            "core-js": "1.2.7",
-            "debug": "2.6.9",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.7",
+            "babel-plugin-constant-folding": "^1.0.1",
+            "babel-plugin-dead-code-elimination": "^1.0.2",
+            "babel-plugin-eval": "^1.0.1",
+            "babel-plugin-inline-environment-variables": "^1.0.1",
+            "babel-plugin-jscript": "^1.0.4",
+            "babel-plugin-member-expression-literals": "^1.0.1",
+            "babel-plugin-property-literals": "^1.0.1",
+            "babel-plugin-proto-to-assign": "^1.0.3",
+            "babel-plugin-react-constant-elements": "^1.0.3",
+            "babel-plugin-react-display-name": "^1.0.3",
+            "babel-plugin-remove-console": "^1.0.1",
+            "babel-plugin-remove-debugger": "^1.0.1",
+            "babel-plugin-runtime": "^1.0.7",
+            "babel-plugin-undeclared-variables-check": "^1.0.2",
+            "babel-plugin-undefined-to-void": "^1.1.6",
+            "babylon": "^5.8.38",
+            "bluebird": "^2.9.33",
+            "chalk": "^1.0.0",
+            "convert-source-map": "^1.1.0",
+            "core-js": "^1.0.0",
+            "debug": "^2.1.1",
+            "detect-indent": "^3.0.0",
+            "esutils": "^2.0.0",
+            "fs-readdir-recursive": "^0.1.0",
+            "globals": "^6.4.0",
+            "home-or-tmp": "^1.0.0",
+            "is-integer": "^1.0.4",
             "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.8",
+            "json5": "^0.4.0",
+            "lodash": "^3.10.0",
+            "minimatch": "^2.0.3",
+            "output-file-sync": "^1.1.0",
+            "path-exists": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "private": "^0.1.6",
             "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "1.4.0",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "0.5.7",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.3",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
+            "regexpu": "^1.3.0",
+            "repeating": "^1.1.2",
+            "resolve": "^1.1.6",
+            "shebang-regex": "^1.0.0",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.0",
+            "source-map-support": "^0.2.10",
+            "to-fast-properties": "^1.0.0",
+            "trim-right": "^1.0.0",
+            "try-resolve": "^1.0.0"
           }
         },
         "babel-plugin-flow-comments": {
@@ -13559,7 +10109,7 @@
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -13568,9 +10118,9 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "chalk": {
@@ -13578,11 +10128,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "chokidar": {
@@ -13590,15 +10140,15 @@
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
           "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
           "requires": {
-            "anymatch": "1.3.2",
-            "async-each": "1.0.1",
-            "fsevents": "1.1.2",
-            "glob-parent": "2.0.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "2.0.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.1.0"
+            "anymatch": "^1.3.0",
+            "async-each": "^1.0.0",
+            "fsevents": "^1.0.0",
+            "glob-parent": "^2.0.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^2.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0"
           }
         },
         "commander": {
@@ -13654,7 +10204,7 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "expand-range": {
@@ -13662,7 +10212,7 @@
           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
           "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
           "requires": {
-            "fill-range": "2.2.3"
+            "fill-range": "^2.1.0"
           }
         },
         "extglob": {
@@ -13670,7 +10220,7 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "filename-regex": {
@@ -13683,11 +10233,11 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
           "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^1.1.3",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "for-in": {
@@ -13700,7 +10250,7 @@
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
           "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
           "requires": {
-            "for-in": "1.0.2"
+            "for-in": "^1.0.1"
           }
         },
         "fs-readdir-recursive": {
@@ -13719,8 +10269,8 @@
           "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
           "optional": true,
           "requires": {
-            "nan": "2.7.0",
-            "node-pre-gyp": "0.6.36"
+            "nan": "^2.3.0",
+            "node-pre-gyp": "^0.6.36"
           },
           "dependencies": {
             "abbrev": {
@@ -13733,13 +10283,14 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
+                "co": "^4.6.0",
+                "json-stable-stringify": "^1.0.1"
               }
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.1.1",
@@ -13751,8 +10302,8 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.2.9"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
               }
             },
             "asn1": {
@@ -13782,41 +10333,46 @@
             },
             "balanced-match": {
               "version": "0.4.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "bcrypt-pbkdf": {
               "version": "1.0.1",
               "bundled": true,
               "optional": true,
               "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
               }
             },
             "block-stream": {
               "version": "0.0.9",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
               }
             },
             "boom": {
               "version": "2.10.1",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
               }
             },
             "brace-expansion": {
               "version": "1.1.7",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "balanced-match": "0.4.2",
+                "balanced-match": "^0.4.1",
                 "concat-map": "0.0.1"
               }
             },
             "buffer-shims": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "caseless": {
               "version": "0.12.0",
@@ -13830,33 +10386,38 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "combined-stream": {
               "version": "1.0.5",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
               }
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "cryptiles": {
               "version": "2.0.5",
               "bundled": true,
               "optional": true,
               "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
               }
             },
             "dashdash": {
@@ -13864,7 +10425,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -13889,7 +10450,8 @@
             },
             "delayed-stream": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "delegates": {
               "version": "1.0.0",
@@ -13901,7 +10463,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
               }
             },
             "extend": {
@@ -13911,7 +10473,8 @@
             },
             "extsprintf": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "forever-agent": {
               "version": "0.6.1",
@@ -13923,23 +10486,25 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.15"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
               }
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "fstream": {
               "version": "1.0.11",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.1"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
               }
             },
             "fstream-ignore": {
@@ -13947,9 +10512,9 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "fstream": "1.0.11",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4"
+                "fstream": "^1.0.0",
+                "inherits": "2",
+                "minimatch": "^3.0.0"
               }
             },
             "gauge": {
@@ -13957,14 +10522,14 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "aproba": "1.1.1",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
               }
             },
             "getpass": {
@@ -13972,7 +10537,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -13985,18 +10550,20 @@
             "glob": {
               "version": "7.1.2",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "graceful-fs": {
               "version": "4.1.11",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "har-schema": {
               "version": "1.0.5",
@@ -14008,8 +10575,8 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
+                "ajv": "^4.9.1",
+                "har-schema": "^1.0.5"
               }
             },
             "has-unicode": {
@@ -14022,37 +10589,40 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
               }
             },
             "hoek": {
               "version": "2.16.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "http-signature": {
               "version": "1.1.1",
               "bundled": true,
               "optional": true,
               "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.0",
-                "sshpk": "1.13.0"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
               }
             },
             "inflight": {
               "version": "1.0.6",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
               }
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.4",
@@ -14062,8 +10632,9 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "is-typedarray": {
@@ -14073,7 +10644,8 @@
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "isstream": {
               "version": "0.1.2",
@@ -14085,7 +10657,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
               }
             },
             "jsbn": {
@@ -14103,7 +10675,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
               }
             },
             "json-stringify-safe": {
@@ -14136,29 +10708,34 @@
             },
             "mime-db": {
               "version": "1.27.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "mime-types": {
               "version": "2.1.15",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "mime-db": "1.27.0"
+                "mime-db": "~1.27.0"
               }
             },
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "brace-expansion": "1.1.7"
+                "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -14173,15 +10750,15 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "mkdirp": "0.5.1",
-                "nopt": "4.0.1",
-                "npmlog": "4.1.0",
-                "rc": "1.2.1",
-                "request": "2.81.0",
-                "rimraf": "2.6.1",
-                "semver": "5.3.0",
-                "tar": "2.2.1",
-                "tar-pack": "3.4.0"
+                "mkdirp": "^0.5.1",
+                "nopt": "^4.0.1",
+                "npmlog": "^4.0.2",
+                "rc": "^1.1.7",
+                "request": "^2.81.0",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^2.2.1",
+                "tar-pack": "^3.4.0"
               }
             },
             "nopt": {
@@ -14189,8 +10766,8 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "abbrev": "1.1.0",
-                "osenv": "0.1.4"
+                "abbrev": "1",
+                "osenv": "^0.1.4"
               }
             },
             "npmlog": {
@@ -14198,15 +10775,16 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "are-we-there-yet": "1.1.4",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
               }
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "oauth-sign": {
               "version": "0.8.2",
@@ -14221,8 +10799,9 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               }
             },
             "os-homedir": {
@@ -14240,13 +10819,14 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
               }
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "performance-now": {
               "version": "0.2.0",
@@ -14255,7 +10835,8 @@
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "punycode": {
               "version": "1.4.1",
@@ -14272,10 +10853,10 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "deep-extend": "0.4.2",
-                "ini": "1.3.4",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "~0.4.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
               },
               "dependencies": {
                 "minimist": {
@@ -14288,14 +10869,15 @@
             "readable-stream": {
               "version": "2.2.9",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "buffer-shims": "1.0.0",
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "1.0.1",
-                "util-deprecate": "1.0.2"
+                "buffer-shims": "~1.0.0",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~1.0.0",
+                "util-deprecate": "~1.0.1"
               }
             },
             "request": {
@@ -14303,40 +10885,42 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.15",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.0.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.2",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.0.1"
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.1.1",
+                "har-validator": "~4.2.1",
+                "hawk": "~3.1.3",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "oauth-sign": "~0.8.1",
+                "performance-now": "^0.2.0",
+                "qs": "~6.4.0",
+                "safe-buffer": "^5.0.1",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.3.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.0.0"
               }
             },
             "rimraf": {
               "version": "2.6.1",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
               }
             },
             "safe-buffer": {
               "version": "5.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "semver": {
               "version": "5.3.0",
@@ -14358,7 +10942,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
               }
             },
             "sshpk": {
@@ -14366,15 +10950,15 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jodid25519": "1.0.2",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jodid25519": "^1.0.0",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -14384,20 +10968,22 @@
                 }
               }
             },
-            "string_decoder": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "5.0.1"
-              }
-            },
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "^5.0.1"
               }
             },
             "stringstream": {
@@ -14408,8 +10994,9 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             },
             "strip-json-comments": {
@@ -14420,10 +11007,11 @@
             "tar": {
               "version": "2.2.1",
               "bundled": true,
+              "optional": true,
               "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
               }
             },
             "tar-pack": {
@@ -14431,14 +11019,14 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "debug": "2.6.8",
-                "fstream": "1.0.11",
-                "fstream-ignore": "1.0.5",
-                "once": "1.4.0",
-                "readable-stream": "2.2.9",
-                "rimraf": "2.6.1",
-                "tar": "2.2.1",
-                "uid-number": "0.0.6"
+                "debug": "^2.2.0",
+                "fstream": "^1.0.10",
+                "fstream-ignore": "^1.0.5",
+                "once": "^1.3.3",
+                "readable-stream": "^2.1.4",
+                "rimraf": "^2.5.1",
+                "tar": "^2.2.1",
+                "uid-number": "^0.0.6"
               }
             },
             "tough-cookie": {
@@ -14446,7 +11034,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
               }
             },
             "tunnel-agent": {
@@ -14454,7 +11042,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "safe-buffer": "5.0.1"
+                "safe-buffer": "^5.0.1"
               }
             },
             "tweetnacl": {
@@ -14469,7 +11057,8 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "uuid": {
               "version": "3.0.1",
@@ -14489,12 +11078,13 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "string-width": "1.0.2"
+                "string-width": "^1.0.2"
               }
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -14503,11 +11093,11 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "glob-base": {
@@ -14515,8 +11105,8 @@
           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
           "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
           "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "glob-parent": {
@@ -14524,7 +11114,7 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "graceful-fs": {
@@ -14537,7 +11127,7 @@
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "inflight": {
@@ -14545,8 +11135,8 @@
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -14559,7 +11149,7 @@
           "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
           "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
           "requires": {
-            "binary-extensions": "1.10.0"
+            "binary-extensions": "^1.0.0"
           }
         },
         "is-buffer": {
@@ -14577,7 +11167,7 @@
           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
           "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
           "requires": {
-            "is-primitive": "2.0.0"
+            "is-primitive": "^2.0.0"
           }
         },
         "is-extendable": {
@@ -14595,7 +11185,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "is-number": {
@@ -14603,7 +11193,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-plain-object": {
@@ -14611,7 +11201,7 @@
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
           "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.1"
           },
           "dependencies": {
             "isobject": {
@@ -14649,7 +11239,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "^1.1.5"
           }
         },
         "micromatch": {
@@ -14657,19 +11247,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         },
         "minimatch": {
@@ -14677,7 +11267,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.0.0"
           }
         },
         "minimist": {
@@ -14709,7 +11299,7 @@
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "requires": {
-            "remove-trailing-separator": "1.1.0"
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "object.omit": {
@@ -14717,8 +11307,8 @@
           "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
           "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
           "requires": {
-            "for-own": "0.1.5",
-            "is-extendable": "0.1.1"
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
           }
         },
         "once": {
@@ -14726,7 +11316,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "output-file-sync": {
@@ -14734,9 +11324,9 @@
           "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
           "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.1"
+            "graceful-fs": "^4.1.4",
+            "mkdirp": "^0.5.1",
+            "object-assign": "^4.1.0"
           }
         },
         "parse-glob": {
@@ -14744,10 +11334,10 @@
           "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
           "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
           "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.3",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "path-exists": {
@@ -14785,8 +11375,8 @@
           "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
           "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
           "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -14794,7 +11384,7 @@
               "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -14802,7 +11392,7 @@
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
-                    "is-buffer": "1.1.5"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -14812,7 +11402,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -14822,13 +11412,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "readdirp": {
@@ -14836,10 +11426,10 @@
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
           "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "minimatch": "3.0.4",
-            "readable-stream": "2.3.3",
-            "set-immediate-shim": "1.0.1"
+            "graceful-fs": "^4.1.2",
+            "minimatch": "^3.0.2",
+            "readable-stream": "^2.0.2",
+            "set-immediate-shim": "^1.0.1"
           },
           "dependencies": {
             "minimatch": {
@@ -14847,7 +11437,7 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
               }
             }
           }
@@ -14857,7 +11447,7 @@
           "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
           "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
           "requires": {
-            "is-equal-shallow": "0.1.3"
+            "is-equal-shallow": "^0.1.3"
           }
         },
         "remove-trailing-separator": {
@@ -14880,7 +11470,7 @@
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
           "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
           "requires": {
-            "path-parse": "1.0.5"
+            "path-parse": "^1.0.5"
           }
         },
         "rimraf": {
@@ -14888,7 +11478,7 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           },
           "dependencies": {
             "glob": {
@@ -14896,12 +11486,12 @@
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
               "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "minimatch": {
@@ -14909,7 +11499,7 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
               }
             }
           }
@@ -14939,7 +11529,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -14947,7 +11537,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -15010,7 +11600,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": "1.4.0"
+            "statuses": ">= 1.3.1 < 2"
           }
         },
         "iconv-lite": {
@@ -15052,26 +11642,32 @@
       "dev": true
     },
     "rc": {
-      "version": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-      "dev": true,
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-        "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-        "minimist": "1.2.0",
-        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       }
+    },
+    "rcedit": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rcedit/-/rcedit-1.1.2.tgz",
+      "integrity": "sha512-z2ypB4gbINhI6wVe0JJMmdpmOpmNc4g90sE6/6JSuch5kYnjfz9CxvVPqqhShgR6GIkmtW3W2UlfiXhWljA0Fw==",
+      "dev": true
     },
     "react": {
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
       "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
       "requires": {
-        "create-react-class": "15.6.2",
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "create-react-class": "^15.6.0",
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.0",
+        "prop-types": "^15.5.10"
       },
       "dependencies": {
         "asap": {
@@ -15089,9 +11685,9 @@
           "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
           "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
           "requires": {
-            "fbjs": "0.8.16",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1"
+            "fbjs": "^0.8.9",
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
           }
         },
         "fbjs": {
@@ -15099,13 +11695,13 @@
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
           "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
           "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.17"
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.9"
           }
         },
         "js-tokens": {
@@ -15118,7 +11714,7 @@
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "promise": {
@@ -15126,7 +11722,7 @@
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
           "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
           "requires": {
-            "asap": "2.0.6"
+            "asap": "~2.0.3"
           }
         },
         "setimmediate": {
@@ -15146,10 +11742,10 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
       "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.0",
+        "prop-types": "^15.5.10"
       },
       "dependencies": {
         "asap": {
@@ -15167,13 +11763,13 @@
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
           "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
           "requires": {
-            "core-js": "1.2.7",
-            "isomorphic-fetch": "2.2.1",
-            "loose-envify": "1.3.1",
-            "object-assign": "4.1.1",
-            "promise": "7.3.1",
-            "setimmediate": "1.0.5",
-            "ua-parser-js": "0.7.17"
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.9"
           }
         },
         "js-tokens": {
@@ -15186,7 +11782,7 @@
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "promise": {
@@ -15194,7 +11790,7 @@
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
           "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
           "requires": {
-            "asap": "2.0.6"
+            "asap": "~2.0.3"
           }
         },
         "setimmediate": {
@@ -15215,8 +11811,8 @@
       "integrity": "sha1-yVZHrni3Pfzv9uxx/8sEGC/22vk=",
       "dev": true,
       "requires": {
-        "react-hot-api": "0.4.7",
-        "source-map": "0.4.4"
+        "react-hot-api": "^0.4.5",
+        "source-map": "^0.4.4"
       },
       "dependencies": {
         "amdefine": {
@@ -15237,7 +11833,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -15247,157 +11843,106 @@
       "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-2.4.1.tgz",
       "integrity": "sha512-3WQCn3xqkbEUvxRUO3nkeqxMNgt1F4CyEU3BiUIrg7C71tnqjQIuSE7+JXp85yFl8X1iRTJouySNpwNqv4kiWg==",
       "requires": {
-        "exenv": "https://registry.npmjs.org/exenv/-/exenv-1.2.1.tgz",
-        "prop-types": "15.6.0"
+        "exenv": "^1.2.0",
+        "prop-types": "^15.5.10"
       }
     },
     "read-config-file": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-1.2.0.tgz",
-      "integrity": "sha512-A1MNfKNIfYV7vXMOQ/CPCuVpCdWoPULu8whmrkKxwN8FUsv6EjwU2SPSNueeTKR6tZPl7+Qeondyb4/pAcoozQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-3.2.2.tgz",
+      "integrity": "sha512-PuFpMgZF01VB0ydH1dfitAxCP/fh+qnfbA9cYNIPoxPbz0SMngsrafCtaHDWfER7MwlDz4fmrNBhPkakxxFpTg==",
       "dev": true,
       "requires": {
-        "ajv": "5.2.4",
-        "ajv-keywords": "2.1.0",
-        "bluebird-lst": "1.0.5",
-        "dotenv": "4.0.0",
-        "dotenv-expand": "4.0.1",
-        "fs-extra-p": "4.4.4",
-        "js-yaml": "3.10.0",
-        "json5": "0.5.1",
-        "lazy-val": "1.0.2"
+        "ajv": "^6.9.2",
+        "ajv-keywords": "^3.4.0",
+        "bluebird-lst": "^1.0.7",
+        "dotenv": "^6.2.0",
+        "dotenv-expand": "^4.2.0",
+        "fs-extra-p": "^7.0.1",
+        "js-yaml": "^3.12.1",
+        "json5": "^2.1.0",
+        "lazy-val": "^1.0.4"
       },
       "dependencies": {
-        "ajv": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
-          "integrity": "sha1-Pa+ai2ciEpn9ro2C0RftjmyAJEs=",
-          "dev": true,
-          "requires": {
-            "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
-          }
-        },
-        "ajv-keywords": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-          "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
-          "dev": true
-        },
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-          "dev": true
-        },
-        "bluebird-lst": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.5.tgz",
-          "integrity": "sha512-Ey0bDNys5qpYPhZ/oQ9vOEvD0TYQDTILMXWP2iGfvMg7rSDde+oV4aQQgqRH+CvBFNz2BSDQnPGMUl6LKBUUQA==",
-          "dev": true,
-          "requires": {
-            "bluebird": "3.5.1"
-          }
-        },
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-          "dev": true
-        },
-        "fast-deep-equal": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-          "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
-          "dev": true
-        },
         "fs-extra": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
           "dev": true,
           "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "fs-extra-p": {
-          "version": "4.4.4",
-          "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.4.4.tgz",
-          "integrity": "sha512-zHsMNJWhXD184QfHKEIFSQSgAFNV7v9J+Nt2XpaLZp2nTz6WxZNV+R4G2uYeGeLTMaKvUZiqGKrH/4iFCupcUA==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-7.0.1.tgz",
+          "integrity": "sha512-yhd2OV0HnHt2oitlp+X9hl2ReX4X/7kQeL7/72qzPHTZj5eUPGzAKOvEglU02Fa1OeG2rSy/aKB4WGVaLiF8tw==",
           "dev": true,
           "requires": {
-            "bluebird-lst": "1.0.5",
-            "fs-extra": "4.0.2"
-          }
-        },
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-          "dev": true,
-          "requires": {
-            "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-            "esprima": "4.0.0"
+            "bluebird-lst": "^1.0.7",
+            "fs-extra": "^7.0.1"
           }
         },
         "json5": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-          "dev": true
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
           "dev": true,
           "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+            "minimist": "^1.2.0"
           }
-        },
-        "universalify": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-          "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-          "dev": true
         }
       }
     },
     "read-pkg": {
-      "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
       "requires": {
-        "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-        "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
-        "path-type": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
-      "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
       "requires": {
-        "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-        "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        }
       }
     },
     "readable-stream": {
-      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-      "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-      "dev": true,
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "requires": {
-        "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
       }
     },
     "recast": {
@@ -15406,9 +11951,9 @@
       "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
       "requires": {
         "ast-types": "0.8.12",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+        "private": "~0.1.5",
+        "source-map": "~0.5.0"
       },
       "dependencies": {
         "ast-types": {
@@ -15424,16 +11969,17 @@
       }
     },
     "redent": {
-      "version": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true,
       "requires": {
-        "indent-string": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-        "strip-indent": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "regenerate": {
-      "version": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
       "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
     },
     "regenerator": {
@@ -15441,12 +11987,12 @@
       "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
       "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
       "requires": {
-        "commoner": "0.10.8",
-        "defs": "1.1.1",
-        "esprima-fb": "15001.1001.0-dev-harmony-fb",
-        "private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+        "commoner": "~0.10.3",
+        "defs": "~1.1.0",
+        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
+        "private": "~0.1.5",
         "recast": "0.10.33",
-        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+        "through": "~2.3.8"
       },
       "dependencies": {
         "esprima-fb": {
@@ -15461,11 +12007,11 @@
       "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
       "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
       "requires": {
-        "esprima": "2.7.3",
-        "recast": "0.10.33",
-        "regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-        "regjsgen": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-        "regjsparser": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+        "esprima": "^2.6.0",
+        "recast": "^0.10.10",
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       },
       "dependencies": {
         "esprima": {
@@ -15475,25 +12021,48 @@
         }
       }
     },
+    "registry-auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
+      "integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
+      "dev": true,
+      "requires": {
+        "rc": "^1.2.8",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "registry-url": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
+      "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
+      "dev": true,
+      "requires": {
+        "rc": "^1.2.8"
+      }
+    },
     "regjsgen": {
-      "version": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
     },
     "regjsparser": {
-      "version": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
-        "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
-          "version": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
     },
     "repeat-string": {
-      "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
@@ -15501,7 +12070,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
       "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       },
       "dependencies": {
         "is-finite": {
@@ -15509,7 +12078,7 @@
           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
           "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "number-is-nan": {
@@ -15520,66 +12089,100 @@
       }
     },
     "request": {
-      "version": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
-      "integrity": "sha1-11wc32eddrsQD5v/4f5VG1wk6T0=",
-      "dev": true,
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
-        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-        "bl": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
-        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-        "form-data": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
-        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
-        "hawk": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
-        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-        "node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
-        "qs": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+        }
       }
     },
     "require-directory": {
-      "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
-      "version": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "resolve": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+    },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
     "right-align": {
-      "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
-        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.1.3"
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "minimatch": "3.0.4",
-            "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -15587,23 +12190,53 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
     },
     "safe-buffer": {
-      "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "dev": true,
+      "requires": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "semver": {
-      "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-      "dev": true
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+    },
+    "semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
+      "requires": {
+        "semver": "^5.0.3"
+      }
     },
     "set-blocking": {
-      "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
@@ -15613,7 +12246,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -15622,46 +12255,63 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "signal-exit": {
-      "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "simple-fmt": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
       "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms="
     },
-    "simple-get": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
-      "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
-      "dev": true,
-      "requires": {
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "unzip-response": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-      }
-    },
     "simple-is": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
       "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA="
     },
+    "single-line-log": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
+      "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
+      "requires": {
+        "string-width": "^1.0.1"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
+      }
+    },
     "slash": {
-      "version": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
     },
-    "sntp": {
-      "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
-      "requires": {
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-      }
+    "source-list-map": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
+      "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
+      "dev": true
     },
     "source-map": {
-      "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
       "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
     },
     "source-map-support": {
@@ -15682,28 +12332,38 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
           "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
     },
     "spdx-correct": {
-      "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true,
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "requires": {
-        "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+    },
     "spdx-expression-parse": {
-      "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
     },
     "spdx-license-ids": {
-      "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-      "dev": true
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
     },
     "spectron": {
       "version": "3.7.2",
@@ -15711,11 +12371,11 @@
       "integrity": "sha1-hvQTBqm3DtbuFQD399Otw4mvtEY=",
       "dev": true,
       "requires": {
-        "dev-null": "0.1.1",
-        "electron-chromedriver": "1.7.1",
-        "request": "2.83.0",
-        "split": "1.0.1",
-        "webdriverio": "4.8.0"
+        "dev-null": "^0.1.1",
+        "electron-chromedriver": "~1.7.1",
+        "request": "^2.81.0",
+        "split": "^1.0.0",
+        "webdriverio": "^4.8.0"
       },
       "dependencies": {
         "ajv": {
@@ -15724,10 +12384,10 @@
           "integrity": "sha1-Pa+ai2ciEpn9ro2C0RftjmyAJEs=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "0.3.1",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "json-schema-traverse": "^0.3.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "amdefine": {
@@ -15760,15 +12420,15 @@
           "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
           "dev": true,
           "requires": {
-            "archiver-utils": "1.3.0",
-            "async": "2.5.0",
-            "buffer-crc32": "0.2.13",
-            "glob": "7.1.2",
-            "lodash": "4.17.4",
-            "readable-stream": "2.3.3",
-            "tar-stream": "1.5.4",
-            "walkdir": "0.0.11",
-            "zip-stream": "1.2.0"
+            "archiver-utils": "^1.3.0",
+            "async": "^2.0.0",
+            "buffer-crc32": "^0.2.1",
+            "glob": "^7.0.0",
+            "lodash": "^4.8.0",
+            "readable-stream": "^2.0.0",
+            "tar-stream": "^1.5.0",
+            "walkdir": "^0.0.11",
+            "zip-stream": "^1.1.0"
           }
         },
         "archiver-utils": {
@@ -15777,12 +12437,12 @@
           "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
           "dev": true,
           "requires": {
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "lazystream": "1.0.0",
-            "lodash": "4.17.4",
-            "normalize-path": "2.1.1",
-            "readable-stream": "2.3.3"
+            "glob": "^7.0.0",
+            "graceful-fs": "^4.1.0",
+            "lazystream": "^1.0.0",
+            "lodash": "^4.8.0",
+            "normalize-path": "^2.0.0",
+            "readable-stream": "^2.0.0"
           }
         },
         "asn1": {
@@ -15803,7 +12463,7 @@
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "asynckit": {
@@ -15836,8 +12496,8 @@
           "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
           "dev": true,
           "requires": {
-            "core-js": "2.5.1",
-            "regenerator-runtime": "0.10.5"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.10.0"
           }
         },
         "balanced-match": {
@@ -15853,7 +12513,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "bl": {
@@ -15862,7 +12522,7 @@
           "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.3"
+            "readable-stream": "^2.0.5"
           }
         },
         "boom": {
@@ -15871,7 +12531,7 @@
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         },
         "brace-expansion": {
@@ -15880,7 +12540,7 @@
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -15902,11 +12562,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           },
           "dependencies": {
             "supports-color": {
@@ -15923,7 +12583,7 @@
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
-            "restore-cursor": "2.0.0"
+            "restore-cursor": "^2.0.0"
           }
         },
         "cli-width": {
@@ -15944,7 +12604,7 @@
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "compress-commons": {
@@ -15953,10 +12613,10 @@
           "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
           "dev": true,
           "requires": {
-            "buffer-crc32": "0.2.13",
-            "crc32-stream": "2.0.0",
-            "normalize-path": "2.1.1",
-            "readable-stream": "2.3.3"
+            "buffer-crc32": "^0.2.1",
+            "crc32-stream": "^2.0.0",
+            "normalize-path": "^2.0.0",
+            "readable-stream": "^2.0.0"
           }
         },
         "concat-map": {
@@ -15971,9 +12631,9 @@
           "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "core-js": {
@@ -16000,8 +12660,8 @@
           "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
           "dev": true,
           "requires": {
-            "crc": "3.5.0",
-            "readable-stream": "2.3.3"
+            "crc": "^3.4.4",
+            "readable-stream": "^2.0.0"
           }
         },
         "cryptiles": {
@@ -16010,7 +12670,7 @@
           "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
           "dev": true,
           "requires": {
-            "boom": "5.2.0"
+            "boom": "5.x.x"
           },
           "dependencies": {
             "boom": {
@@ -16019,7 +12679,7 @@
               "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
               "dev": true,
               "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.x.x"
               }
             }
           }
@@ -16030,10 +12690,10 @@
           "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "source-map": "0.1.43",
-            "source-map-resolve": "0.3.1",
-            "urix": "0.1.0"
+            "inherits": "^2.0.1",
+            "source-map": "^0.1.38",
+            "source-map-resolve": "^0.3.0",
+            "urix": "^0.1.0"
           }
         },
         "css-parse": {
@@ -16042,7 +12702,7 @@
           "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
           "dev": true,
           "requires": {
-            "css": "2.2.1"
+            "css": "^2.0.0"
           }
         },
         "css-value": {
@@ -16057,7 +12717,7 @@
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "debug": {
@@ -16094,7 +12754,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "ejs": {
@@ -16109,8 +12769,8 @@
           "integrity": "sha1-AIyXl2AHqk6xhJHuCV6U0X7kdhA=",
           "dev": true,
           "requires": {
-            "electron-download": "4.1.0",
-            "extract-zip": "1.6.5"
+            "electron-download": "^4.1.0",
+            "extract-zip": "^1.6.5"
           }
         },
         "end-of-stream": {
@@ -16119,7 +12779,7 @@
           "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
           "dev": true,
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.4.0"
           }
         },
         "escape-string-regexp": {
@@ -16140,9 +12800,9 @@
           "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
           "dev": true,
           "requires": {
-            "iconv-lite": "0.4.19",
-            "jschardet": "1.5.1",
-            "tmp": "0.0.33"
+            "iconv-lite": "^0.4.17",
+            "jschardet": "^1.4.2",
+            "tmp": "^0.0.33"
           }
         },
         "extract-zip": {
@@ -16169,7 +12829,7 @@
           "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
           "dev": true,
           "requires": {
-            "pend": "1.2.0"
+            "pend": "~1.2.0"
           }
         },
         "figures": {
@@ -16178,7 +12838,7 @@
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5"
+            "escape-string-regexp": "^1.0.5"
           }
         },
         "forever-agent": {
@@ -16193,9 +12853,9 @@
           "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs.realpath": {
@@ -16210,7 +12870,7 @@
           "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
           "dev": true,
           "requires": {
-            "globule": "1.2.0"
+            "globule": "^1.0.0"
           }
         },
         "getpass": {
@@ -16219,7 +12879,7 @@
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "glob": {
@@ -16228,12 +12888,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globule": {
@@ -16242,9 +12902,9 @@
           "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
           "dev": true,
           "requires": {
-            "glob": "7.1.2",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4"
+            "glob": "~7.1.1",
+            "lodash": "~4.17.4",
+            "minimatch": "~3.0.2"
           }
         },
         "graceful-fs": {
@@ -16265,8 +12925,8 @@
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "dev": true,
           "requires": {
-            "ajv": "5.2.4",
-            "har-schema": "2.0.0"
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
           }
         },
         "has-ansi": {
@@ -16275,7 +12935,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "has-flag": {
@@ -16290,10 +12950,10 @@
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
           "dev": true,
           "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.0.2"
+            "boom": "4.x.x",
+            "cryptiles": "3.x.x",
+            "hoek": "4.x.x",
+            "sntp": "2.x.x"
           }
         },
         "hoek": {
@@ -16308,9 +12968,9 @@
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "iconv-lite": {
@@ -16325,8 +12985,8 @@
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -16341,19 +13001,19 @@
           "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
           "dev": true,
           "requires": {
-            "ansi-escapes": "1.4.0",
-            "chalk": "1.1.3",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "2.0.5",
-            "figures": "2.0.0",
-            "lodash": "4.17.4",
+            "ansi-escapes": "^1.1.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.1",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
             "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rx": "4.1.0",
-            "string-width": "2.1.1",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rx": "^4.1.0",
+            "string-width": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
           }
         },
         "is-fullwidth-code-point": {
@@ -16411,7 +13071,7 @@
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -16444,7 +13104,7 @@
           "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.3"
+            "readable-stream": "^2.0.5"
           }
         },
         "lodash": {
@@ -16465,7 +13125,7 @@
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "dev": true,
           "requires": {
-            "mime-db": "1.30.0"
+            "mime-db": "~1.30.0"
           }
         },
         "mimic-fn": {
@@ -16480,7 +13140,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -16516,7 +13176,7 @@
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "1.1.0"
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "npm-install-package": {
@@ -16537,7 +13197,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "onetime": {
@@ -16546,7 +13206,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.1.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "optimist": {
@@ -16555,8 +13215,8 @@
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
           }
         },
         "os-tmpdir": {
@@ -16619,13 +13279,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "regenerator-runtime": {
@@ -16646,28 +13306,28 @@
           "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           }
         },
         "resolve-url": {
@@ -16682,8 +13342,8 @@
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "rgb2hex": {
@@ -16698,7 +13358,7 @@
           "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
           "dev": true,
           "requires": {
-            "is-promise": "2.1.0"
+            "is-promise": "^2.1.0"
           }
         },
         "rx": {
@@ -16725,7 +13385,7 @@
           "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         },
         "source-map": {
@@ -16734,7 +13394,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "source-map-resolve": {
@@ -16743,10 +13403,10 @@
           "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
           "dev": true,
           "requires": {
-            "atob": "1.1.3",
-            "resolve-url": "0.2.1",
-            "source-map-url": "0.3.0",
-            "urix": "0.1.0"
+            "atob": "~1.1.0",
+            "resolve-url": "~0.2.1",
+            "source-map-url": "~0.3.0",
+            "urix": "~0.1.0"
           }
         },
         "source-map-url": {
@@ -16761,7 +13421,7 @@
           "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
           "dev": true,
           "requires": {
-            "through": "2.3.8"
+            "through": "2"
           }
         },
         "sshpk": {
@@ -16770,23 +13430,14 @@
           "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
           "dev": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
           }
         },
         "string-width": {
@@ -16795,8 +13446,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -16811,9 +13462,18 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
           }
         },
         "stringstream": {
@@ -16828,7 +13488,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -16837,7 +13497,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         },
         "tar-stream": {
@@ -16846,10 +13506,10 @@
           "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
           "dev": true,
           "requires": {
-            "bl": "1.2.1",
-            "end-of-stream": "1.4.0",
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
+            "bl": "^1.0.0",
+            "end-of-stream": "^1.0.0",
+            "readable-stream": "^2.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "through": {
@@ -16864,7 +13524,7 @@
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2"
+            "os-tmpdir": "~1.0.2"
           }
         },
         "tough-cookie": {
@@ -16873,7 +13533,7 @@
           "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
           "dev": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "tunnel-agent": {
@@ -16882,7 +13542,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -16940,9 +13600,9 @@
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
+            "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
+            "extsprintf": "^1.2.0"
           }
         },
         "wdio-dot-reporter": {
@@ -16957,28 +13617,28 @@
           "integrity": "sha1-1Skpt0kID4mWf24WFAUcvIFy0TI=",
           "dev": true,
           "requires": {
-            "archiver": "1.3.0",
-            "babel-runtime": "6.23.0",
-            "css-parse": "2.0.0",
-            "css-value": "0.0.1",
-            "deepmerge": "1.3.2",
-            "ejs": "2.5.7",
-            "gaze": "1.1.2",
-            "glob": "7.1.2",
-            "inquirer": "3.0.6",
-            "json-stringify-safe": "5.0.1",
-            "mkdirp": "0.5.1",
-            "npm-install-package": "2.1.0",
-            "optimist": "0.6.1",
-            "q": "1.5.1",
-            "request": "2.81.0",
-            "rgb2hex": "0.1.0",
-            "safe-buffer": "5.0.1",
-            "supports-color": "3.2.3",
-            "url": "0.11.0",
-            "validator": "7.0.0",
-            "wdio-dot-reporter": "0.0.9",
-            "wgxpath": "1.0.0"
+            "archiver": "~1.3.0",
+            "babel-runtime": "~6.23.0",
+            "css-parse": "~2.0.0",
+            "css-value": "~0.0.1",
+            "deepmerge": "~1.3.2",
+            "ejs": "~2.5.6",
+            "gaze": "~1.1.2",
+            "glob": "~7.1.1",
+            "inquirer": "~3.0.6",
+            "json-stringify-safe": "~5.0.1",
+            "mkdirp": "~0.5.1",
+            "npm-install-package": "~2.1.0",
+            "optimist": "~0.6.1",
+            "q": "~1.5.0",
+            "request": "~2.81.0",
+            "rgb2hex": "~0.1.0",
+            "safe-buffer": "~5.0.1",
+            "supports-color": "~3.2.3",
+            "url": "~0.11.0",
+            "validator": "~7.0.0",
+            "wdio-dot-reporter": "~0.0.8",
+            "wgxpath": "~1.0.0"
           },
           "dependencies": {
             "ajv": {
@@ -16987,8 +13647,8 @@
               "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
               "dev": true,
               "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
+                "co": "^4.6.0",
+                "json-stable-stringify": "^1.0.1"
               }
             },
             "assert-plus": {
@@ -17009,7 +13669,7 @@
               "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
               "dev": true,
               "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
               }
             },
             "cryptiles": {
@@ -17018,7 +13678,7 @@
               "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
               "dev": true,
               "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
               }
             },
             "form-data": {
@@ -17027,9 +13687,9 @@
               "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
               "dev": true,
               "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
               }
             },
             "har-schema": {
@@ -17044,8 +13704,8 @@
               "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
               "dev": true,
               "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
+                "ajv": "^4.9.1",
+                "har-schema": "^1.0.5"
               }
             },
             "hawk": {
@@ -17054,10 +13714,10 @@
               "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
               "dev": true,
               "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
               }
             },
             "hoek": {
@@ -17072,9 +13732,9 @@
               "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
               "dev": true,
               "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
               }
             },
             "mkdirp": {
@@ -17104,28 +13764,28 @@
               "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
               "dev": true,
               "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.0.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.1.1",
+                "har-validator": "~4.2.1",
+                "hawk": "~3.1.3",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "oauth-sign": "~0.8.1",
+                "performance-now": "^0.2.0",
+                "qs": "~6.4.0",
+                "safe-buffer": "^5.0.1",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.3.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.0.0"
               }
             },
             "safe-buffer": {
@@ -17140,7 +13800,7 @@
               "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
               "dev": true,
               "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
               }
             }
           }
@@ -17175,7 +13835,7 @@
           "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
           "dev": true,
           "requires": {
-            "fd-slicer": "1.0.1"
+            "fd-slicer": "~1.0.1"
           }
         },
         "zip-stream": {
@@ -17184,27 +13844,50 @@
           "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
           "dev": true,
           "requires": {
-            "archiver-utils": "1.3.0",
-            "compress-commons": "1.2.2",
-            "lodash": "4.17.4",
-            "readable-stream": "2.3.3"
+            "archiver-utils": "^1.3.0",
+            "compress-commons": "^1.2.0",
+            "lodash": "^4.8.0",
+            "readable-stream": "^2.0.0"
           }
         }
       }
     },
     "speedometer": {
-      "version": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
-      "integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0=",
-      "dev": true
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
+      "integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0="
     },
     "sprintf-js": {
-      "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
     },
     "stable": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
       "integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA="
+    },
+    "stat-mode": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.3.0.tgz",
+      "integrity": "sha512-QjMLR0A3WwFY2aZdV0okfFEJB5TRjkggXZjxP3A1RsWsNHNu3YPv8btmtc6iCFZ0Rul3FE93OYogvhOUClU+ng==",
+      "dev": true
     },
     "stats-webpack-plugin": {
       "version": "0.2.2",
@@ -17212,23 +13895,38 @@
       "integrity": "sha1-fWqDlmnKZ5CanbgB1QK8OVzGZpU=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-      "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
+    "string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dev": true,
       "requires": {
-        "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
-    "string-width": {
-      "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-      }
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringmap": {
       "version": "0.2.2",
@@ -17240,39 +13938,40 @@
       "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
       "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU="
     },
-    "stringstream": {
-      "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
-    },
     "strip-ansi": {
-      "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
-        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
-      "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
       "requires": {
-        "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+        "is-utf8": "^0.2.0"
       }
     },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
     "strip-indent": {
-      "version": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true,
       "requires": {
-        "get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
-      "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "style-loader": {
       "version": "0.12.4",
@@ -17280,7 +13979,7 @@
       "integrity": "sha1-rn0GZdxNxlPaov6Xu5CRS8HSLZs=",
       "dev": true,
       "requires": {
-        "loader-utils": "0.2.17"
+        "loader-utils": "^0.2.7"
       },
       "dependencies": {
         "big.js": {
@@ -17307,164 +14006,82 @@
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "dev": true,
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
           }
+        }
+      }
+    },
+    "sumchecker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-2.0.2.tgz",
+      "integrity": "sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
     "supports-color": {
-      "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
-    "tar-fs": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
-      "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
-      "dev": true,
-      "requires": {
-        "chownr": "1.0.1",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "pump": "1.0.2",
-        "tar-stream": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz"
-      }
-    },
-    "tar-stream": {
-      "version": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
-      "integrity": "sha1-+8bG6DwaGdTLSMfZYXH8JI7/x78=",
-      "dev": true,
-      "requires": {
-        "bl": "https://registry.npmjs.org/bl/-/bl-1.2.0.tgz",
-        "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "https://registry.npmjs.org/bl/-/bl-1.2.0.tgz",
-          "integrity": "sha1-E5fn7ELF9dw4dHDFAONKn2vp6pg=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
-          }
-        }
-      }
-    },
     "temp-file": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-2.0.3.tgz",
-      "integrity": "sha512-qN0iNW0DFNmog1BFS8J3rQK4sZRIqqUZJ/zFlFo+0PwE7adUTEpPrQ3toWxwTcDjtGL9HjsQWe8CqMKq1kM7Gw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.3.4.tgz",
+      "integrity": "sha512-qSZ5W5q54iyGnP8cNl49RE0jTJc5CrzNocux5APD5yIxcgonoMuMSbsZfaZy8rTGCYo0Xz6ySVv3adagZ8gffg==",
       "dev": true,
       "requires": {
-        "async-exit-hook": "2.0.1",
-        "bluebird-lst": "1.0.5",
-        "fs-extra-p": "4.4.4",
-        "lazy-val": "1.0.2"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-          "dev": true
-        },
-        "bluebird-lst": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.5.tgz",
-          "integrity": "sha512-Ey0bDNys5qpYPhZ/oQ9vOEvD0TYQDTILMXWP2iGfvMg7rSDde+oV4aQQgqRH+CvBFNz2BSDQnPGMUl6LKBUUQA==",
-          "dev": true,
-          "requires": {
-            "bluebird": "3.5.1"
-          }
-        },
-        "fs-extra": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.1"
-          }
-        },
-        "fs-extra-p": {
-          "version": "4.4.4",
-          "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.4.4.tgz",
-          "integrity": "sha512-zHsMNJWhXD184QfHKEIFSQSgAFNV7v9J+Nt2XpaLZp2nTz6WxZNV+R4G2uYeGeLTMaKvUZiqGKrH/4iFCupcUA==",
-          "dev": true,
-          "requires": {
-            "bluebird-lst": "1.0.5",
-            "fs-extra": "4.0.2"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-          }
-        },
-        "universalify": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-          "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
-          "dev": true
-        }
+        "async-exit-hook": "^2.0.1",
+        "fs-extra": "^8.1.0"
+      }
+    },
+    "term-size": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
+      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
+      "requires": {
+        "execa": "^0.7.0"
       }
     },
     "throttleit": {
-      "version": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
-      "dev": true
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8="
     },
     "through": {
-      "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
-      "version": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
       "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
-      "dev": true,
       "requires": {
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-          }
-        },
-        "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "dev": true,
-          "requires": {
-            "object-keys": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
-          }
-        }
+        "readable-stream": "~1.1.9",
+        "xtend": "~2.1.1"
       }
     },
     "time-stamp": {
@@ -17473,23 +14090,82 @@
       "integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=",
       "dev": true
     },
-    "tough-cookie": {
-      "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+    "tmp": {
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+      "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
       "dev": true,
       "requires": {
-        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+        "os-tmpdir": "~1.0.1"
       }
     },
-    "trim-newlines": {
-      "version": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+    "to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
       "dev": true
     },
+    "touch": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+      "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
+      "dev": true,
+      "requires": {
+        "nopt": "~1.0.10"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        }
+      }
+    },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
+      }
+    },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+      "dev": true
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+    },
     "trim-right": {
-      "version": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "dev": true,
+      "requires": {
+        "utf8-byte-length": "^1.0.1"
+      }
     },
     "try-resolve": {
       "version": "1.0.1",
@@ -17502,19 +14178,107 @@
       "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys="
     },
     "tunnel-agent": {
-      "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
       "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uc.micro": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
-      "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
-    "unzip-response": {
-      "version": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "^1.0.0"
+      }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "update-notifier": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
+      "integrity": "sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==",
+      "dev": true,
+      "requires": {
+        "boxen": "^3.0.0",
+        "chalk": "^2.0.1",
+        "configstore": "^4.0.0",
+        "has-yarn": "^2.1.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^2.0.0",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^3.0.0",
+        "is-yarn-global": "^0.3.0",
+        "latest-version": "^5.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
     },
     "url-loader": {
       "version": "0.5.9",
@@ -17522,8 +14286,8 @@
       "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "mime": "1.3.6"
+        "loader-utils": "^1.0.2",
+        "mime": "1.3.x"
       },
       "dependencies": {
         "big.js": {
@@ -17550,9 +14314,9 @@
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1"
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0"
           }
         },
         "mime": {
@@ -17563,15 +14327,30 @@
         }
       }
     },
+    "url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^2.0.0"
+      }
+    },
     "user-home": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
       "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
     },
-    "util-deprecate": {
-      "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
       "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.1.0",
@@ -17579,12 +14358,22 @@
       "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "validate-npm-package-license": {
-      "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true,
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "requires": {
-        "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-        "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
     "walkdir": {
@@ -17599,21 +14388,21 @@
       "integrity": "sha1-T/MfU9sDM55VFkqdRo7gMklo/pg=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0",
-        "async": "1.5.2",
-        "clone": "1.0.2",
-        "enhanced-resolve": "0.9.1",
-        "interpret": "0.6.6",
-        "loader-utils": "0.2.17",
-        "memory-fs": "0.3.0",
-        "mkdirp": "0.5.1",
-        "node-libs-browser": "0.7.0",
-        "optimist": "0.6.1",
-        "supports-color": "3.2.3",
-        "tapable": "0.1.10",
-        "uglify-js": "2.7.5",
-        "watchpack": "0.2.9",
-        "webpack-core": "0.6.9"
+        "acorn": "^3.0.0",
+        "async": "^1.3.0",
+        "clone": "^1.0.2",
+        "enhanced-resolve": "~0.9.0",
+        "interpret": "^0.6.4",
+        "loader-utils": "^0.2.11",
+        "memory-fs": "~0.3.0",
+        "mkdirp": "~0.5.0",
+        "node-libs-browser": "^0.7.0",
+        "optimist": "~0.6.0",
+        "supports-color": "^3.1.0",
+        "tapable": "~0.1.8",
+        "uglify-js": "~2.7.3",
+        "watchpack": "^0.2.1",
+        "webpack-core": "~0.6.9"
       },
       "dependencies": {
         "acorn": {
@@ -17628,9 +14417,9 @@
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2",
-            "longest": "1.0.1",
-            "repeat-string": "1.6.1"
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
           }
         },
         "amdefine": {
@@ -17645,8 +14434,8 @@
           "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
           "dev": true,
           "requires": {
-            "micromatch": "2.3.11",
-            "normalize-path": "2.1.1"
+            "micromatch": "^2.1.5",
+            "normalize-path": "^2.0.0"
           }
         },
         "arr-diff": {
@@ -17655,7 +14444,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "arr-flatten": {
@@ -17721,7 +14510,7 @@
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -17731,9 +14520,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "browserify-aes": {
@@ -17742,7 +14531,7 @@
           "integrity": "sha1-BnFJtmjfMcS1hTPgLQHoBthgjiw=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "^2.0.1"
           }
         },
         "browserify-zlib": {
@@ -17751,7 +14540,7 @@
           "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
           "dev": true,
           "requires": {
-            "pako": "0.2.9"
+            "pako": "~0.2.0"
           }
         },
         "buffer": {
@@ -17760,9 +14549,9 @@
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "dev": true,
           "requires": {
-            "base64-js": "1.2.1",
-            "ieee754": "1.1.8",
-            "isarray": "1.0.0"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
           }
         },
         "builtin-status-codes": {
@@ -17783,8 +14572,8 @@
           "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "dev": true,
           "requires": {
-            "align-text": "0.1.4",
-            "lazy-cache": "1.0.4"
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
           }
         },
         "chokidar": {
@@ -17793,15 +14582,15 @@
           "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
           "dev": true,
           "requires": {
-            "anymatch": "1.3.2",
-            "async-each": "1.0.1",
-            "fsevents": "1.1.2",
-            "glob-parent": "2.0.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "2.0.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.1.0"
+            "anymatch": "^1.3.0",
+            "async-each": "^1.0.0",
+            "fsevents": "^1.0.0",
+            "glob-parent": "^2.0.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^2.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0"
           }
         },
         "cliui": {
@@ -17810,8 +14599,8 @@
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           },
           "dependencies": {
@@ -17841,7 +14630,7 @@
           "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
           "dev": true,
           "requires": {
-            "date-now": "0.1.4"
+            "date-now": "^0.1.4"
           }
         },
         "constants-browserify": {
@@ -17898,9 +14687,9 @@
           "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "memory-fs": "0.2.0",
-            "tapable": "0.1.10"
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.2.0",
+            "tapable": "^0.1.8"
           },
           "dependencies": {
             "memory-fs": {
@@ -17917,7 +14706,7 @@
           "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
           "dev": true,
           "requires": {
-            "prr": "0.0.0"
+            "prr": "~0.0.0"
           }
         },
         "events": {
@@ -17932,7 +14721,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "expand-range": {
@@ -17941,7 +14730,7 @@
           "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
           "dev": true,
           "requires": {
-            "fill-range": "2.2.3"
+            "fill-range": "^2.1.0"
           }
         },
         "extglob": {
@@ -17950,7 +14739,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "filename-regex": {
@@ -17965,11 +14754,11 @@
           "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^1.1.3",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "for-in": {
@@ -17984,7 +14773,7 @@
           "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
           "dev": true,
           "requires": {
-            "for-in": "1.0.2"
+            "for-in": "^1.0.1"
           }
         },
         "fsevents": {
@@ -17994,8 +14783,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "nan": "2.7.0",
-            "node-pre-gyp": "0.6.36"
+            "nan": "^2.3.0",
+            "node-pre-gyp": "^0.6.36"
           },
           "dependencies": {
             "abbrev": {
@@ -18010,14 +14799,15 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
+                "co": "^4.6.0",
+                "json-stable-stringify": "^1.0.1"
               }
             },
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.1.1",
@@ -18031,8 +14821,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.2.9"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
               }
             },
             "asn1": {
@@ -18068,7 +14858,8 @@
             "balanced-match": {
               "version": "0.4.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "bcrypt-pbkdf": {
               "version": "1.0.1",
@@ -18076,38 +14867,42 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
               }
             },
             "block-stream": {
               "version": "0.0.9",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
               }
             },
             "boom": {
               "version": "2.10.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
               }
             },
             "brace-expansion": {
               "version": "1.1.7",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
-                "balanced-match": "0.4.2",
+                "balanced-match": "^0.4.1",
                 "concat-map": "0.0.1"
               }
             },
             "buffer-shims": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "caseless": {
               "version": "0.12.0",
@@ -18124,30 +14919,35 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "combined-stream": {
               "version": "1.0.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
               }
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "cryptiles": {
               "version": "2.0.5",
@@ -18155,7 +14955,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
               }
             },
             "dashdash": {
@@ -18164,7 +14964,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -18193,7 +14993,8 @@
             "delayed-stream": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "delegates": {
               "version": "1.0.0",
@@ -18207,7 +15008,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
               }
             },
             "extend": {
@@ -18219,7 +15020,8 @@
             "extsprintf": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "forever-agent": {
               "version": "0.6.1",
@@ -18233,25 +15035,27 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.15"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
               }
             },
             "fs.realpath": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "fstream": {
               "version": "1.0.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.1"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
               }
             },
             "fstream-ignore": {
@@ -18260,9 +15064,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "fstream": "1.0.11",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4"
+                "fstream": "^1.0.0",
+                "inherits": "2",
+                "minimatch": "^3.0.0"
               }
             },
             "gauge": {
@@ -18271,14 +15075,14 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "aproba": "1.1.1",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
               }
             },
             "getpass": {
@@ -18287,7 +15091,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -18302,19 +15106,21 @@
               "version": "7.1.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "graceful-fs": {
               "version": "4.1.11",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "har-schema": {
               "version": "1.0.5",
@@ -18328,8 +15134,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
+                "ajv": "^4.9.1",
+                "har-schema": "^1.0.5"
               }
             },
             "has-unicode": {
@@ -18344,16 +15150,17 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
               }
             },
             "hoek": {
               "version": "2.16.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "http-signature": {
               "version": "1.1.1",
@@ -18361,24 +15168,26 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.0",
-                "sshpk": "1.13.0"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
               }
             },
             "inflight": {
               "version": "1.0.6",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
               }
             },
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.4",
@@ -18390,8 +15199,9 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "is-typedarray": {
@@ -18403,7 +15213,8 @@
             "isarray": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "isstream": {
               "version": "0.1.2",
@@ -18417,7 +15228,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
               }
             },
             "jsbn": {
@@ -18438,7 +15249,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
               }
             },
             "json-stringify-safe": {
@@ -18476,33 +15287,38 @@
             "mime-db": {
               "version": "1.27.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "mime-types": {
               "version": "2.1.15",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
-                "mime-db": "1.27.0"
+                "mime-db": "~1.27.0"
               }
             },
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
-                "brace-expansion": "1.1.7"
+                "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -18519,15 +15335,15 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "mkdirp": "0.5.1",
-                "nopt": "4.0.1",
-                "npmlog": "4.1.0",
-                "rc": "1.2.1",
-                "request": "2.81.0",
-                "rimraf": "2.6.1",
-                "semver": "5.3.0",
-                "tar": "2.2.1",
-                "tar-pack": "3.4.0"
+                "mkdirp": "^0.5.1",
+                "nopt": "^4.0.1",
+                "npmlog": "^4.0.2",
+                "rc": "^1.1.7",
+                "request": "^2.81.0",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^2.2.1",
+                "tar-pack": "^3.4.0"
               }
             },
             "nopt": {
@@ -18536,8 +15352,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "abbrev": "1.1.0",
-                "osenv": "0.1.4"
+                "abbrev": "1",
+                "osenv": "^0.1.4"
               }
             },
             "npmlog": {
@@ -18546,16 +15362,17 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "are-we-there-yet": "1.1.4",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
               }
             },
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "oauth-sign": {
               "version": "0.8.2",
@@ -18573,8 +15390,9 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               }
             },
             "os-homedir": {
@@ -18595,14 +15413,15 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
               }
             },
             "path-is-absolute": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "performance-now": {
               "version": "0.2.0",
@@ -18613,7 +15432,8 @@
             "process-nextick-args": {
               "version": "1.0.7",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "punycode": {
               "version": "1.4.1",
@@ -18633,10 +15453,10 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "deep-extend": "0.4.2",
-                "ini": "1.3.4",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "~0.4.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
               },
               "dependencies": {
                 "minimist": {
@@ -18651,14 +15471,15 @@
               "version": "2.2.9",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
-                "buffer-shims": "1.0.0",
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "1.0.1",
-                "util-deprecate": "1.0.2"
+                "buffer-shims": "~1.0.0",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~1.0.0",
+                "util-deprecate": "~1.0.1"
               }
             },
             "request": {
@@ -18667,42 +15488,44 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.15",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.0.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.2",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.0.1"
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.1.1",
+                "har-validator": "~4.2.1",
+                "hawk": "~3.1.3",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "oauth-sign": "~0.8.1",
+                "performance-now": "^0.2.0",
+                "qs": "~6.4.0",
+                "safe-buffer": "^5.0.1",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.3.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.0.0"
               }
             },
             "rimraf": {
               "version": "2.6.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
               }
             },
             "safe-buffer": {
               "version": "5.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "semver": {
               "version": "5.3.0",
@@ -18728,7 +15551,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
               }
             },
             "sshpk": {
@@ -18737,15 +15560,15 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jodid25519": "1.0.2",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jodid25519": "^1.0.0",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -18756,22 +15579,24 @@
                 }
               }
             },
-            "string_decoder": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "safe-buffer": "5.0.1"
-              }
-            },
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "^5.0.1"
               }
             },
             "stringstream": {
@@ -18784,8 +15609,9 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             },
             "strip-json-comments": {
@@ -18798,10 +15624,11 @@
               "version": "2.2.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
               }
             },
             "tar-pack": {
@@ -18810,14 +15637,14 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "debug": "2.6.8",
-                "fstream": "1.0.11",
-                "fstream-ignore": "1.0.5",
-                "once": "1.4.0",
-                "readable-stream": "2.2.9",
-                "rimraf": "2.6.1",
-                "tar": "2.2.1",
-                "uid-number": "0.0.6"
+                "debug": "^2.2.0",
+                "fstream": "^1.0.10",
+                "fstream-ignore": "^1.0.5",
+                "once": "^1.3.3",
+                "readable-stream": "^2.1.4",
+                "rimraf": "^2.5.1",
+                "tar": "^2.2.1",
+                "uid-number": "^0.0.6"
               }
             },
             "tough-cookie": {
@@ -18826,7 +15653,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
               }
             },
             "tunnel-agent": {
@@ -18835,7 +15662,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "safe-buffer": "5.0.1"
+                "safe-buffer": "^5.0.1"
               }
             },
             "tweetnacl": {
@@ -18853,7 +15680,8 @@
             "util-deprecate": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "uuid": {
               "version": "3.0.1",
@@ -18876,13 +15704,14 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "string-width": "1.0.2"
+                "string-width": "^1.0.2"
               }
             },
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -18892,8 +15721,8 @@
           "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
           "dev": true,
           "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "glob-parent": {
@@ -18902,7 +15731,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "graceful-fs": {
@@ -18953,7 +15782,7 @@
           "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
           "dev": true,
           "requires": {
-            "binary-extensions": "1.10.0"
+            "binary-extensions": "^1.0.0"
           }
         },
         "is-buffer": {
@@ -18974,7 +15803,7 @@
           "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
           "dev": true,
           "requires": {
-            "is-primitive": "2.0.0"
+            "is-primitive": "^2.0.0"
           }
         },
         "is-extendable": {
@@ -18995,7 +15824,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "is-number": {
@@ -19004,7 +15833,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-posix-bracket": {
@@ -19046,7 +15875,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "^1.1.5"
           }
         },
         "lazy-cache": {
@@ -19061,10 +15890,10 @@
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "dev": true,
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
           }
         },
         "longest": {
@@ -19079,8 +15908,8 @@
           "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
           "dev": true,
           "requires": {
-            "errno": "0.1.4",
-            "readable-stream": "2.3.3"
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
           }
         },
         "micromatch": {
@@ -19089,19 +15918,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         },
         "minimatch": {
@@ -19110,7 +15939,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -19141,28 +15970,28 @@
           "integrity": "sha1-PicsCBnjCJNeJmdECNevDhSRuDs=",
           "dev": true,
           "requires": {
-            "assert": "1.4.1",
-            "browserify-zlib": "0.1.4",
-            "buffer": "4.9.1",
-            "console-browserify": "1.1.0",
-            "constants-browserify": "1.0.0",
+            "assert": "^1.1.1",
+            "browserify-zlib": "^0.1.4",
+            "buffer": "^4.9.0",
+            "console-browserify": "^1.1.0",
+            "constants-browserify": "^1.0.0",
             "crypto-browserify": "3.3.0",
-            "domain-browser": "1.1.7",
-            "events": "1.1.1",
+            "domain-browser": "^1.1.1",
+            "events": "^1.0.0",
             "https-browserify": "0.0.1",
-            "os-browserify": "0.2.1",
+            "os-browserify": "^0.2.0",
             "path-browserify": "0.0.0",
-            "process": "0.11.10",
-            "punycode": "1.4.1",
-            "querystring-es3": "0.2.1",
-            "readable-stream": "2.3.3",
-            "stream-browserify": "2.0.1",
-            "stream-http": "2.7.2",
-            "string_decoder": "0.10.31",
-            "timers-browserify": "2.0.4",
+            "process": "^0.11.0",
+            "punycode": "^1.2.4",
+            "querystring-es3": "^0.2.0",
+            "readable-stream": "^2.0.5",
+            "stream-browserify": "^2.0.1",
+            "stream-http": "^2.3.1",
+            "string_decoder": "^0.10.25",
+            "timers-browserify": "^2.0.2",
             "tty-browserify": "0.0.0",
-            "url": "0.11.0",
-            "util": "0.10.3",
+            "url": "^0.11.0",
+            "util": "^0.10.3",
             "vm-browserify": "0.0.4"
           },
           "dependencies": {
@@ -19180,7 +16009,7 @@
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "1.1.0"
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "object.omit": {
@@ -19189,8 +16018,8 @@
           "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
           "dev": true,
           "requires": {
-            "for-own": "0.1.5",
-            "is-extendable": "0.1.1"
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
           }
         },
         "optimist": {
@@ -19199,8 +16028,8 @@
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
           }
         },
         "os-browserify": {
@@ -19221,10 +16050,10 @@
           "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
           "dev": true,
           "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.3",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "path-browserify": {
@@ -19293,8 +16122,8 @@
           "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
           "dev": true,
           "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -19303,7 +16132,7 @@
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -19312,7 +16141,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.5"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -19323,7 +16152,7 @@
               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -19334,13 +16163,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "readdirp": {
@@ -19349,10 +16178,10 @@
           "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "minimatch": "3.0.4",
-            "readable-stream": "2.3.3",
-            "set-immediate-shim": "1.0.1"
+            "graceful-fs": "^4.1.2",
+            "minimatch": "^3.0.2",
+            "readable-stream": "^2.0.2",
+            "set-immediate-shim": "^1.0.1"
           }
         },
         "regex-cache": {
@@ -19361,7 +16190,7 @@
           "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
           "dev": true,
           "requires": {
-            "is-equal-shallow": "0.1.3"
+            "is-equal-shallow": "^0.1.3"
           }
         },
         "remove-trailing-separator": {
@@ -19388,7 +16217,7 @@
           "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "dev": true,
           "requires": {
-            "align-text": "0.1.4"
+            "align-text": "^0.1.1"
           }
         },
         "ripemd160": {
@@ -19439,8 +16268,8 @@
           "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3"
+            "inherits": "~2.0.1",
+            "readable-stream": "^2.0.2"
           }
         },
         "stream-http": {
@@ -19449,11 +16278,11 @@
           "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
           "dev": true,
           "requires": {
-            "builtin-status-codes": "3.0.0",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "to-arraybuffer": "1.0.1",
-            "xtend": "4.0.1"
+            "builtin-status-codes": "^3.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.2.6",
+            "to-arraybuffer": "^1.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "string_decoder": {
@@ -19462,7 +16291,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "supports-color": {
@@ -19471,7 +16300,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         },
         "tapable": {
@@ -19486,7 +16315,7 @@
           "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
           "dev": true,
           "requires": {
-            "setimmediate": "1.0.5"
+            "setimmediate": "^1.0.4"
           }
         },
         "to-arraybuffer": {
@@ -19507,10 +16336,10 @@
           "integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
           "dev": true,
           "requires": {
-            "async": "0.2.10",
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "async": "~0.2.6",
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           },
           "dependencies": {
             "async": {
@@ -19583,9 +16412,9 @@
           "integrity": "sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws=",
           "dev": true,
           "requires": {
-            "async": "0.9.2",
-            "chokidar": "1.7.0",
-            "graceful-fs": "4.1.11"
+            "async": "^0.9.0",
+            "chokidar": "^1.0.0",
+            "graceful-fs": "^4.1.2"
           },
           "dependencies": {
             "async": {
@@ -19602,8 +16431,8 @@
           "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
           "dev": true,
           "requires": {
-            "source-list-map": "0.1.8",
-            "source-map": "0.4.4"
+            "source-list-map": "~0.1.7",
+            "source-map": "~0.4.1"
           },
           "dependencies": {
             "source-map": {
@@ -19612,7 +16441,7 @@
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "dev": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
               }
             }
           }
@@ -19641,9 +16470,9 @@
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -19655,19 +16484,19 @@
       "integrity": "sha1-DL1fLSrI1OWTqs1clwLnu9XlmJI=",
       "dev": true,
       "requires": {
-        "compression": "1.7.1",
-        "connect-history-api-fallback": "1.4.0",
-        "express": "4.16.2",
-        "http-proxy-middleware": "0.17.4",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
         "open": "0.0.5",
-        "optimist": "0.6.1",
-        "serve-index": "1.9.1",
-        "sockjs": "0.3.19",
-        "sockjs-client": "1.1.4",
-        "stream-cache": "0.0.2",
-        "strip-ansi": "3.0.1",
-        "supports-color": "3.2.3",
-        "webpack-dev-middleware": "1.12.0"
+        "optimist": "~0.6.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.10.2"
       },
       "dependencies": {
         "accepts": {
@@ -19676,7 +16505,7 @@
           "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
           "dev": true,
           "requires": {
-            "mime-types": "2.1.17",
+            "mime-types": "~2.1.16",
             "negotiator": "0.6.1"
           }
         },
@@ -19692,7 +16521,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "arr-flatten": {
@@ -19725,9 +16554,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "bytes": {
@@ -19742,7 +16571,7 @@
           "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
           "dev": true,
           "requires": {
-            "mime-db": "1.30.0"
+            "mime-db": ">= 1.30.0 < 2"
           }
         },
         "compression": {
@@ -19751,13 +16580,13 @@
           "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
           "dev": true,
           "requires": {
-            "accepts": "1.3.4",
+            "accepts": "~1.3.4",
             "bytes": "3.0.0",
-            "compressible": "2.0.12",
+            "compressible": "~2.0.11",
             "debug": "2.6.9",
-            "on-headers": "1.0.1",
+            "on-headers": "~1.0.1",
             "safe-buffer": "5.1.1",
-            "vary": "1.1.2"
+            "vary": "~1.1.2"
           }
         },
         "connect-history-api-fallback": {
@@ -19835,7 +16664,7 @@
           "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
           "dev": true,
           "requires": {
-            "prr": "0.0.0"
+            "prr": "~0.0.0"
           }
         },
         "escape-html": {
@@ -19862,7 +16691,7 @@
           "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
           "dev": true,
           "requires": {
-            "original": "1.0.0"
+            "original": ">=0.0.5"
           }
         },
         "expand-brackets": {
@@ -19871,7 +16700,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "expand-range": {
@@ -19880,7 +16709,7 @@
           "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
           "dev": true,
           "requires": {
-            "fill-range": "2.2.3"
+            "fill-range": "^2.1.0"
           }
         },
         "express": {
@@ -19889,36 +16718,36 @@
           "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
           "dev": true,
           "requires": {
-            "accepts": "1.3.4",
+            "accepts": "~1.3.4",
             "array-flatten": "1.1.1",
             "body-parser": "1.18.2",
             "content-disposition": "0.5.2",
-            "content-type": "1.0.4",
+            "content-type": "~1.0.4",
             "cookie": "0.3.1",
             "cookie-signature": "1.0.6",
             "debug": "2.6.9",
-            "depd": "1.1.1",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
+            "depd": "~1.1.1",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
             "finalhandler": "1.1.0",
             "fresh": "0.5.2",
             "merge-descriptors": "1.0.1",
-            "methods": "1.1.2",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
             "path-to-regexp": "0.1.7",
-            "proxy-addr": "2.0.2",
+            "proxy-addr": "~2.0.2",
             "qs": "6.5.1",
-            "range-parser": "1.2.0",
+            "range-parser": "~1.2.0",
             "safe-buffer": "5.1.1",
             "send": "0.16.1",
             "serve-static": "1.13.1",
             "setprototypeof": "1.1.0",
-            "statuses": "1.3.1",
-            "type-is": "1.6.15",
+            "statuses": "~1.3.1",
+            "type-is": "~1.6.15",
             "utils-merge": "1.0.1",
-            "vary": "1.1.2"
+            "vary": "~1.1.2"
           }
         },
         "extglob": {
@@ -19927,7 +16756,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           },
           "dependencies": {
             "is-extglob": {
@@ -19944,7 +16773,7 @@
           "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
           "dev": true,
           "requires": {
-            "websocket-driver": "0.7.0"
+            "websocket-driver": ">=0.5.1"
           }
         },
         "filename-regex": {
@@ -19959,11 +16788,11 @@
           "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^1.1.3",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "finalhandler": {
@@ -19973,12 +16802,12 @@
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "statuses": "1.3.1",
-            "unpipe": "1.0.0"
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "statuses": "~1.3.1",
+            "unpipe": "~1.0.0"
           }
         },
         "for-in": {
@@ -19993,7 +16822,7 @@
           "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
           "dev": true,
           "requires": {
-            "for-in": "1.0.2"
+            "for-in": "^1.0.1"
           }
         },
         "forwarded": {
@@ -20014,8 +16843,8 @@
           "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
           "dev": true,
           "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
           },
           "dependencies": {
             "is-extglob": {
@@ -20030,7 +16859,7 @@
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             }
           }
@@ -20041,7 +16870,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           },
           "dependencies": {
             "is-extglob": {
@@ -20056,7 +16885,7 @@
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             }
           }
@@ -20076,7 +16905,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": "1.3.1"
+            "statuses": ">= 1.3.1 < 2"
           },
           "dependencies": {
             "setprototypeof": {
@@ -20093,8 +16922,8 @@
           "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
           "dev": true,
           "requires": {
-            "eventemitter3": "1.2.0",
-            "requires-port": "1.0.0"
+            "eventemitter3": "1.x.x",
+            "requires-port": "1.x.x"
           }
         },
         "http-proxy-middleware": {
@@ -20103,10 +16932,10 @@
           "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
           "dev": true,
           "requires": {
-            "http-proxy": "1.16.2",
-            "is-glob": "3.1.0",
-            "lodash": "4.17.4",
-            "micromatch": "2.3.11"
+            "http-proxy": "^1.16.2",
+            "is-glob": "^3.1.0",
+            "lodash": "^4.17.2",
+            "micromatch": "^2.3.11"
           }
         },
         "inherits": {
@@ -20139,7 +16968,7 @@
           "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
           "dev": true,
           "requires": {
-            "is-primitive": "2.0.0"
+            "is-primitive": "^2.0.0"
           }
         },
         "is-extendable": {
@@ -20160,7 +16989,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         },
         "is-number": {
@@ -20169,7 +16998,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-posix-bracket": {
@@ -20211,7 +17040,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "^1.1.5"
           }
         },
         "lodash": {
@@ -20232,8 +17061,8 @@
           "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
           "dev": true,
           "requires": {
-            "errno": "0.1.4",
-            "readable-stream": "2.3.3"
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
           }
         },
         "merge-descriptors": {
@@ -20254,19 +17083,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           },
           "dependencies": {
             "is-extglob": {
@@ -20281,7 +17110,7 @@
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             }
           }
@@ -20304,7 +17133,7 @@
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "dev": true,
           "requires": {
-            "mime-db": "1.30.0"
+            "mime-db": "~1.30.0"
           }
         },
         "minimist": {
@@ -20331,7 +17160,7 @@
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "1.1.0"
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "object.omit": {
@@ -20340,8 +17169,8 @@
           "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
           "dev": true,
           "requires": {
-            "for-own": "0.1.5",
-            "is-extendable": "0.1.1"
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
           }
         },
         "on-finished": {
@@ -20371,8 +17200,8 @@
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.10",
-            "wordwrap": "0.0.3"
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
           }
         },
         "original": {
@@ -20381,7 +17210,7 @@
           "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
           "dev": true,
           "requires": {
-            "url-parse": "1.0.5"
+            "url-parse": "1.0.x"
           },
           "dependencies": {
             "url-parse": {
@@ -20390,8 +17219,8 @@
               "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
               "dev": true,
               "requires": {
-                "querystringify": "0.0.4",
-                "requires-port": "1.0.0"
+                "querystringify": "0.0.x",
+                "requires-port": "1.0.x"
               }
             }
           }
@@ -20402,10 +17231,10 @@
           "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
           "dev": true,
           "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.3",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
           },
           "dependencies": {
             "is-extglob": {
@@ -20420,7 +17249,7 @@
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             }
           }
@@ -20461,7 +17290,7 @@
           "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
           "dev": true,
           "requires": {
-            "forwarded": "0.1.2",
+            "forwarded": "~0.1.2",
             "ipaddr.js": "1.5.2"
           }
         },
@@ -20489,8 +17318,8 @@
           "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
           "dev": true,
           "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -20499,7 +17328,7 @@
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -20508,7 +17337,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.5"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -20519,7 +17348,7 @@
               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -20536,13 +17365,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "regex-cache": {
@@ -20551,7 +17380,7 @@
           "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
           "dev": true,
           "requires": {
-            "is-equal-shallow": "0.1.3"
+            "is-equal-shallow": "^0.1.3"
           }
         },
         "remove-trailing-separator": {
@@ -20591,18 +17420,18 @@
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "depd": "1.1.1",
-            "destroy": "1.0.4",
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
+            "depd": "~1.1.1",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "1.6.2",
+            "http-errors": "~1.6.2",
             "mime": "1.4.1",
             "ms": "2.0.0",
-            "on-finished": "2.3.0",
-            "range-parser": "1.2.0",
-            "statuses": "1.3.1"
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.3.1"
           }
         },
         "serve-index": {
@@ -20611,13 +17440,13 @@
           "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
           "dev": true,
           "requires": {
-            "accepts": "1.3.4",
+            "accepts": "~1.3.4",
             "batch": "0.6.1",
             "debug": "2.6.9",
-            "escape-html": "1.0.3",
-            "http-errors": "1.6.2",
-            "mime-types": "2.1.17",
-            "parseurl": "1.3.2"
+            "escape-html": "~1.0.3",
+            "http-errors": "~1.6.2",
+            "mime-types": "~2.1.17",
+            "parseurl": "~1.3.2"
           }
         },
         "serve-static": {
@@ -20626,9 +17455,9 @@
           "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
           "dev": true,
           "requires": {
-            "encodeurl": "1.0.1",
-            "escape-html": "1.0.3",
-            "parseurl": "1.3.2",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.2",
             "send": "0.16.1"
           }
         },
@@ -20644,8 +17473,8 @@
           "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
           "dev": true,
           "requires": {
-            "faye-websocket": "0.10.0",
-            "uuid": "3.1.0"
+            "faye-websocket": "^0.10.0",
+            "uuid": "^3.0.1"
           }
         },
         "sockjs-client": {
@@ -20654,12 +17483,12 @@
           "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
+            "debug": "^2.6.6",
             "eventsource": "0.1.6",
-            "faye-websocket": "0.11.1",
-            "inherits": "2.0.3",
-            "json3": "3.3.2",
-            "url-parse": "1.1.9"
+            "faye-websocket": "~0.11.0",
+            "inherits": "^2.0.1",
+            "json3": "^3.3.2",
+            "url-parse": "^1.1.8"
           },
           "dependencies": {
             "faye-websocket": {
@@ -20668,7 +17497,7 @@
               "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
               "dev": true,
               "requires": {
-                "websocket-driver": "0.7.0"
+                "websocket-driver": ">=0.5.1"
               }
             }
           }
@@ -20691,7 +17520,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -20700,7 +17529,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "supports-color": {
@@ -20709,7 +17538,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         },
         "type-is": {
@@ -20719,7 +17548,7 @@
           "dev": true,
           "requires": {
             "media-typer": "0.3.0",
-            "mime-types": "2.1.17"
+            "mime-types": "~2.1.15"
           }
         },
         "unpipe": {
@@ -20734,8 +17563,8 @@
           "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
           "dev": true,
           "requires": {
-            "querystringify": "1.0.0",
-            "requires-port": "1.0.0"
+            "querystringify": "~1.0.0",
+            "requires-port": "1.0.x"
           },
           "dependencies": {
             "querystringify": {
@@ -20770,11 +17599,11 @@
           "integrity": "sha1-007++y7dp+HTtdvgcolRMhllFwk=",
           "dev": true,
           "requires": {
-            "memory-fs": "0.4.1",
-            "mime": "1.4.1",
-            "path-is-absolute": "1.0.1",
-            "range-parser": "1.2.0",
-            "time-stamp": "2.0.0"
+            "memory-fs": "~0.4.1",
+            "mime": "^1.3.4",
+            "path-is-absolute": "^1.0.0",
+            "range-parser": "^1.0.3",
+            "time-stamp": "^2.0.0"
           }
         },
         "websocket-driver": {
@@ -20783,8 +17612,8 @@
           "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
           "dev": true,
           "requires": {
-            "http-parser-js": "0.4.9",
-            "websocket-extensions": "0.1.2"
+            "http-parser-js": ">=0.4.0",
+            "websocket-extensions": ">=0.1.1"
           }
         },
         "websocket-extensions": {
@@ -20801,34 +17630,79 @@
         }
       }
     },
-    "webpack-target-electron-renderer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/webpack-target-electron-renderer/-/webpack-target-electron-renderer-0.1.1.tgz",
-      "integrity": "sha1-eZ52X4j7f52UBwTROFldlrdeqe0=",
+    "webpack-sources": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
+      "integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
       "dev": true,
       "requires": {
-        "webpack": "1.15.0"
+        "source-list-map": "~0.1.7",
+        "source-map": "~0.5.3"
+      }
+    },
+    "webpack-target-electron-renderer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/webpack-target-electron-renderer/-/webpack-target-electron-renderer-0.4.0.tgz",
+      "integrity": "sha1-UJM3CIVgRM/vFBk8qvMgriGc/aI=",
+      "dev": true,
+      "requires": {
+        "webpack": "^1.12.0"
       }
     },
     "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
     "which": {
-      "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+        "isexe": "^2.0.0"
       }
     },
-    "wide-align": {
-      "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "widest-line": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
       "dev": true,
       "requires": {
-        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+        "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "window-size": {
@@ -20837,35 +17711,177 @@
       "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
     },
     "wordwrap": {
-      "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
       "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
     },
     "wrap-ansi": {
-      "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "requires": {
-        "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "wrappy": {
-      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "write-file-atomic": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "xdg-basedir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "dev": true
+    },
     "xmldom": {
-      "version": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
       "dev": true
     },
     "xtend": {
-      "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+      "requires": {
+        "object-keys": "~0.4.0"
+      }
     },
     "y18n": {
-      "version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+      "dev": true,
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
+      }
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "requires": {
+        "fd-slicer": "~1.0.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "url": "http://github.com/skevy/graphiql-app.git"
   },
   "dependencies": {
+    "electron-prebuilt": "^1.4.13",
     "graphiql": "^0.12.0",
     "graphql": "^0.13.2",
     "lodash": "^3.10.1",
@@ -64,6 +65,7 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.4",
     "github-latest-release": "^0.1.1",
+    "graphiql-explorer": "^0.4.2",
     "html-loader": "^0.3.0",
     "ignore-loader": "^0.1.2",
     "json-loader": "^0.5.3",


### PR DESCRIPTION
Adds the latest version of the [GraphiQL Explorer extension](https://www.onegraph.com/blog/2019/01/24/How_OneGraph_onboards_users_new_to_GraphQL.html).

This PR isn't fully working, as the queries aren't saving properly on tab switching, but I wanted to get this basic idea up first before going too far.

Here's a preview of it in action:
![graphiql-app-explorer-preview](https://user-images.githubusercontent.com/35296/64565681-27f45080-d309-11e9-9df6-bceeff864ba3.gif)
