### PR TITLE
Updates the way to install using brew as `brew cask` is not supported anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Provides a tabbed interface for editing and testing GraphQL queries/mutations wi
 If you have [Homebrew](http://brew.sh/) installed on macOS:
 
 ```
-brew cask install graphiql
+brew install --cask graphiql
 ```
 
 Alternately, download the binary from the [Releases](https://github.com/skevy/graphiql-app/releases) tab.


### PR DESCRIPTION
Calling brew cask install is disabled! Use brew install [--cask] instead