### PR TITLE
Remove Force Flag from dist-clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start-dev": "NODE_ENV=development electron .",
     "start-hot": "HOT=1 NODE_ENV=development electron .",
     "package": "build --dir",
-    "dist-clean": "rm -rf ./dist ./release",
+    "dist-clean": "rm -r ./dist ./release",
     "dist": "build -mwl",
     "release": "yarn dist-clean && yarn build && build -mwl",
     "test": "npm run build",


### PR DESCRIPTION
Just a minor update that may not effect anyone, but could probably make more people aware that the force flag isn't needed in userland.