### PR TITLE
OSX: Close App When All  Windows Closed

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ crashReporter.start({
 var mainWindow = null;
 
 app.on('window-all-closed', function() {
-  if (process.platform !== 'darwin') app.quit();
+  app.quit();
 });
 
 


### PR DESCRIPTION
**Fix**
Closes the app when the renderer process is stopped when using on OSX, so menu item errors cannot be thrown.

**Reason:** 
What lead me to this PR, was that the menu items will throw errors when the renderer is closed. This update makes sure the main process is killed with the renderer process, so this cannot happen.

The main process menu items requires the webContents object to be present, and without a tray menu, I'm not seeing a reason for the app to stay open after the main renderer process closes in OSX. Maybe I'm overlooking something?