### PR TITLE
Remove `--cask` option from example `brew install` command in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Provides a tabbed interface for editing and testing GraphQL queries/mutations wi
 If you have [Homebrew](http://brew.sh/) installed on macOS:
 
 ```
-brew install --cask graphiql
+brew install graphiql
 ```
 
 Alternately, download the binary from the [Releases](https://github.com/skevy/graphiql-app/releases) tab.


### PR DESCRIPTION
You no longer need to specify the `--cask` option with `brew install` to install Homebrew Casks, so this removes that from the documentation.